### PR TITLE
Bug in selec/cons_res using tasks-per-node and cpus-per-task

### DIFF
--- a/src/plugins/select/cons_res/dist_tasks.c
+++ b/src/plugins/select/cons_res/dist_tasks.c
@@ -85,7 +85,7 @@ static int _compute_c_b_task_dist(struct job_record *job_ptr)
 		if (job_ptr->details->ntasks_per_node == 0)
 			maxtasks = maxtasks / job_ptr->details->cpus_per_task;
 		else
-			maxtasks = job_ptr->details->ntasks_per_node;
+			maxtasks = job_ptr->details->ntasks_per_node * job_res->nhosts;
 	}
 
 	/* Safe guard if the user didn't specified a lower number of


### PR DESCRIPTION
tasks_per_node and cpus_per_task are not getting proper allocation and
failing in srun with "Requested node configuration is not available"

with the current version I'm getting:
sbatch --tasks-per-node=1 -c 2 -n 2 --wrap="srun /bin/hostname"
srun: error: Unable to create job step: Requested node configuration is not available

This happens with every job requesting tasks-per-node and cpus-per-task > 1

This patch solves this problem, and sets maxtask to ntasks_per_node \* nhosts
