### PR TITLE
Fixes bug with squeue -t CONFIGURING

### DIFF
--- a/src/common/slurm_protocol_defs.c
+++ b/src/common/slurm_protocol_defs.c
@@ -1061,8 +1061,8 @@ int job_state_num(const char *state_name)
 
 	if (_job_name_test(JOB_COMPLETING, state_name))
 		return JOB_COMPLETING;
-	if (_job_name_test(JOB_COMPLETING, state_name))
-		return JOB_COMPLETING;
+	if (_job_name_test(JOB_CONFIGURING, state_name))
+		return JOB_CONFIGURING;
 	if (_job_name_test(JOB_RESIZING, state_name))
 		return JOB_RESIZING;
 


### PR DESCRIPTION
Before this fix:  squeue -t configuring
squeue: error: Invalid job state specified: configuring
squeue: error: Valid job states include: PENDING,RUNNING,SUSPENDED,COMPLETED,CANCELLED,FAILED,TIMEOUT,NODE_FAIL,COMPLETING,CONFIGURING
