### PR TITLE
not testing gres_cpus in cons_res/job_test.c can lead to fatal error in slurmctld

### DIFF
--- a/src/plugins/select/cons_res/job_test.c
+++ b/src/plugins/select/cons_res/job_test.c
@@ -649,6 +649,10 @@ uint16_t _can_job_run_on_node(struct job_record *job_ptr, bitstr_t *core_map,
 					 core_map, core_start_bit,
 					 core_end_bit, job_ptr->job_id,
 					 node_ptr->name);
+	if ((gres_cpus < job_ptr->details->ntasks_per_node) ||
+	    ((job_ptr->details->cpus_per_task > 1) &&
+	     (gres_cpus < job_ptr->details->cpus_per_task)))
+		gres_cpus = 0;
 	if (gres_cpus < cpus)
 		cpus = gres_cpus;
 


### PR DESCRIPTION
With an invalid configuration a user can cause a:
"fatal: cons_res: sync loop not progressing" in the controller
With this patch a job will be rejected if asking for unavailable configuration.
