### PR TITLE
Fixing a problem about counting backfilling scheduling statistics

### DIFF
--- a/src/plugins/sched/backfill/backfill.c
+++ b/src/plugins/sched/backfill/backfill.c
@@ -529,6 +529,7 @@ static int _attempt_backfill(void)
 	int job_test_count = 0;
 	uint32_t *uid = NULL, nuser = 0;
 	uint16_t *njobs = NULL;
+    int already_counted;
 
 #ifdef HAVE_CRAY
 	/*
@@ -610,6 +611,7 @@ static int _attempt_backfill(void)
 			info("backfill test for job %u", job_ptr->job_id);
 
 		slurmctld_diag_stats.bf_last_depth++;
+        already_counted = 0;
 
 		if (max_backfill_job_per_user) {
 			for (j = 0; j < nuser; j++) {
@@ -789,7 +791,11 @@ static int _attempt_backfill(void)
 		debug2("backfill: entering _try_sched for job %u.",
 		       job_ptr->job_id);
 
-		slurmctld_diag_stats.bf_last_depth_try++;
+		if(!already_counted){
+            slurmctld_diag_stats.bf_last_depth_try++;
+            already_counted = 1;
+        }
+
 		j = _try_sched(job_ptr, &avail_bitmap, min_nodes, max_nodes,
 			       req_nodes, exc_core_bitmap);
 		now = time(NULL);

--- a/src/slurmctld/controller.c
+++ b/src/slurmctld/controller.c
@@ -1580,7 +1580,7 @@ static void *_slurmctld_background(void *no_data)
 			/* Resetting stats values */
 			last_proc_req_start = now;
 			next_stats_reset = now - (now % 86400) + 86400;
-			reset_stats();
+			reset_stats(0);
 		}
 
 		/* Reassert this machine as the primary controller.

--- a/src/slurmctld/proc_req.c
+++ b/src/slurmctld/proc_req.c
@@ -4278,7 +4278,7 @@ static void _slurm_rpc_dump_stats(slurm_msg_t * msg)
 	response_msg.msg_type = RESPONSE_STATS_INFO;
 
 	if (request_msg->command_id == STAT_COMMAND_RESET) {
-		reset_stats();
+		reset_stats(1);
 		pack_all_stat(0, &dump, &dump_size, msg->protocol_version);
 		response_msg.data = dump;
 		response_msg.data_size = dump_size;

--- a/src/slurmctld/slurmctld.h
+++ b/src/slurmctld/slurmctld.h
@@ -1568,7 +1568,7 @@ extern void reset_first_job_id(void);
 extern void reset_job_bitmaps (void);
 
 /* Reset all scheduling statistics */
-extern void reset_stats(void);
+extern void reset_stats(int level);
 
 /*
  * restore_node_features - Make node and config (from slurm.conf) fields

--- a/src/slurmctld/statistics.c
+++ b/src/slurmctld/statistics.c
@@ -126,7 +126,7 @@ extern void pack_all_stat(int resp, char **buffer_ptr, int *buffer_size,
 }
 
 /* Reset all scheduling statistics */
-extern void reset_stats(void)
+extern void reset_stats(int level)
 {
 	slurmctld_diag_stats.proc_req_raw = 0;
 	slurmctld_diag_stats.proc_req_threads = 0;
@@ -140,7 +140,10 @@ extern void reset_stats(void)
 	slurmctld_diag_stats.jobs_canceled = 0;
 	slurmctld_diag_stats.jobs_failed = 0;
 
-	slurmctld_diag_stats.backfilled_jobs = 0;
+    /* Just resetting this value when reset requested explicitly */
+	if(level)
+        slurmctld_diag_stats.backfilled_jobs = 0;
+
 	slurmctld_diag_stats.last_backfilled_jobs = 0;
 	slurmctld_diag_stats.bf_cycle_counter = 0;
 	slurmctld_diag_stats.bf_cycle_sum = 0;


### PR DESCRIPTION
Also:

Adding a reset level in reset_stats for controlling values to reset
