### PR TITLE
Fix building with glibc-2.16

### DIFF
--- a/src/salloc/salloc.c
+++ b/src/salloc/salloc.c
@@ -42,9 +42,7 @@
 #  include "config.h"
 #endif
 
-#if defined(__NetBSD__)
 #include <sys/resource.h> /* for struct rlimit */
-#endif
 #include <dirent.h>
 #include <fcntl.h>
 #include <pwd.h>

--- a/src/sbatch/sbatch.c
+++ b/src/sbatch/sbatch.c
@@ -41,9 +41,7 @@
 #  include "config.h"
 #endif
 
-#if defined(__NetBSD__)
 #include <sys/resource.h> /* for RLIMIT_NOFILE */
-#endif
 #include <pwd.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/srun/libsrun/srun_job.c
+++ b/src/srun/libsrun/srun_job.c
@@ -45,6 +45,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <sys/resource.h>
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <sys/stat.h>


### PR DESCRIPTION
Due to yet another change in header files made by glibc's maintainers <sys/resource.h> is required in couple of places.
For build failure with slurm-2.3.4 please see: http://tinyurl.com/c5fuvsg
Downstream bug report: https://bugs.gentoo.org/show_bug.cgi?id=430252
