### PR TITLE
Core based reservations: using nodes with available cores

### DIFF
--- a/testsuite/expect/inc3.11.1
+++ b/testsuite/expect/inc3.11.1
@@ -32,8 +32,13 @@
 ############################################################################
 
 proc inc3_11_1 {} {
-	global def_node user_name def_partition exit_code res_name
+	global def_node user_name def_partition exit_code cluster_cpus cores_per_node res_name
 
+	set num_nodes [available_nodes $def_partition]
+	
+	# First setting core_res_num greater than cores per node (assuming symmetric nodes)
+	set core_res_num [ expr ($cluster_cpus / $num_nodes) + 1 ]
+	
 	# TEST 1
 	# Make a list of lists with a series of parameters to test.  All the tests
 	# in goodtests should pass, all those in badtests should fail.
@@ -54,25 +59,28 @@ proc inc3_11_1 {} {
 	{StartTime=now   Duration=5   Nodes=$def_node   User=$user_name  Flags=badtype,ignore_jobs}
 	{StartTime=now+10minutes   EndTime=now   Nodes=$def_node   User=$user_name Flags=ignore_jobs}
 	{StartTime=now   Duration=5   Nodes=$def_node   User=$user_name Licenses=DUMMY_FOR_TESTING Flags=ignore_jobs}
+	#{StartTime=now   Duration=5   NodeCnt=2 CoreCnt=1  User=$user_name}
+	{StartTime=now   Duration=5   NodeCnt=1 CoreCnt=$core_res_num  User=$user_name}
 "
 	#	{StartTime=now   Duration=5   Nodes=$def_node   Account=badaccountname}
 
 	foreach test $badtests {
 		set ret_code [create_res $test 1]
 		if {$ret_code == 0} {
-			send_user "\nFAILURE: Reservation $test did not fail but should have\n"
+			send_user "\n\033\[31mFAILURE: Reservation $test did not fail but should have\033\[m\n"
 			delete_res $res_name
 			exit 1
 		} else {
-			send_user "Expected error.  You can turn that frown upside-down.\n"
+			send_user "\033\[32mExpected error.  You can turn that frown upside-down.\033\[m\n"
 		}
 	}
 
 	if {[test_super_user] == 0} {
-		send_user "\nWARNING: can not test more unless SlurmUser or root\n"
+		send_user "\n\033\[34mWARNING: can not test more unless SlurmUser or root\033\[m\n"
 		exit $exit_code
 	}
 
+	set core_res_num [ expr $cluster_cpus / 2 ]
 	set goodtests "
 	{StartTime=now   Duration=5   Nodes=$def_node   User=$user_name Flags=ignore_jobs}
 	{StartTime=now+5minutes   EndTime=now+10minutes   Nodes=$def_node   User=$user_name Flags=ignore_jobs}
@@ -81,17 +89,23 @@ proc inc3_11_1 {} {
 	{StartTime=now   Duration=5   NodeCnt=1   User=$user_name Flags=ignore_jobs}
 	{StartTime=now   Duration=5   Nodes=$def_node   User=$user_name  PartitionName=$def_partition Flags=ignore_jobs}
 	{StartTime=now   Duration=5   Nodes=$def_node   User=$user_name  Flags=Maint Flags=ignore_jobs}
+	{StartTime=now   Duration=5   NodeCnt=$num_nodes CoreCnt=$core_res_num  User=$user_name}
+	{StartTime=now   Duration=5   NodeCnt=10 CoreCnt=11  User=$user_name}
 "
 	foreach test $goodtests {
 		set ret_code [create_res $test 0]
 		if {$ret_code != 0} {
-			send_user "\nFAILURE: Unable to create a valid reservation\n"
+			send_user "\n\033\[31mFAILURE: Unable to create a valid reservation\033\[m\n"
 			exit $ret_code
+		} else {
+			send_user "\033\[32mReservation created as expected.\033\[m\n"
 		}
 		set ret_code [delete_res $res_name]
 		if {$ret_code != 0} {
-			send_user "\nFAILURE: Unable to delete a reservation\n"
+			send_user "\n\033\[31mFAILURE: Unable to delete a reservation\033\[m\n"
 			exit $ret_code
+		} else {
+			send_user "\033\[32mReservation deleted as expected.\033\[m\n"
 		}
 	}
 }

--- a/testsuite/expect/inc3.11.2
+++ b/testsuite/expect/inc3.11.2
@@ -38,7 +38,7 @@ proc inc3_11_2 {} {
 	send_user "\n+++++ STARTING TEST 2 +++++\n"
 	set ret_code [create_res "StartTime=now+60minutes Duration=60 NodeCnt=1 User=$user_name" 0]
 	if {$ret_code != 0} {
-		send_user "\nFAILURE: Unable to create a valid reservation\n"
+		send_user "\n\033\[31mFAILURE: Unable to create a valid reservation\033\[m\n"
 		exit $ret_code
 	}
 
@@ -60,16 +60,18 @@ proc inc3_11_2 {} {
 	foreach test $goodupdates {
 		set ret_code [update_res $res_name $test 0]
 		if {$ret_code != 0} {
-			send_user "\nFAILURE: Unable to create a valid reservation\n"
+			send_user "\n\033\[31mFAILURE: Unable to update a valid reservation\033\[m\n"
 			set exit_code 1
 			break
+		} else {
+			send_user "\n\033\[32mReservation was updated as expected\033\[m\n"
 		}
 
 	}
 
 	set ret_code [delete_res $res_name]
 	if {$ret_code != 0} {
-		send_user "\nFAILURE: Unable to delete a reservation\n"
+		send_user "\n\033\[31mFAILURE: Unable to delete a reservation\033\[m\n"
 		exit $ret_code
 	}
 }

--- a/testsuite/expect/inc3.11.3
+++ b/testsuite/expect/inc3.11.3
@@ -41,7 +41,7 @@ proc inc3_11_3 {} {
 	# Make the reservation
 	set ret_code [create_res "StartTime=now+60minutes Duration=60 NodeCnt=1 User=$user_name" 0]
 	if {$ret_code != 0} {
-		send_user "\nFAILURE: Unable to create a valid reservation\n"
+		send_user "\n\033\[31mFAILURE: Unable to create a valid reservation\033\[m\n"
 		exit $ret_code
 	}
 
@@ -57,7 +57,7 @@ proc inc3_11_3 {} {
 			exp_continue
 		}
 		timeout {
-			send_user "\nFAILURE: sbatch not responding\n"
+			send_user "\n\033\[31mFAILURE: sbatch not responding\033\[m\n"
 			slow_kill $sbatch_pid
 			set exit_code 1
 		}
@@ -66,7 +66,7 @@ proc inc3_11_3 {} {
 		}
 	}
 	if {$job_id == 0} {
-		send_user "\nFAILURE: batch submit failure\n"
+		send_user "\n\033\[31mFAILURE: batch submit failure\033\[m\n"
 		exit 1
 	}
 
@@ -76,20 +76,20 @@ proc inc3_11_3 {} {
 		-re "Reservation=($alpha_numeric_under)" {
 			set tmp_res_name $expect_out(1,string)
 			if {$tmp_res_name != $res_name} {
-				send_user "\nFAILURE: problem submitting a job to a "
+				send_user "\n\033\[31mFAILURE: problem submitting a job to a "
 				send_user "reservation.  Job $job_id is running on "
-				send_user "reservation $tmp_res_name, not $res_name\n"
+				send_user "reservation $tmp_res_name, not $res_name\033\[m\n"
 				set exit_code 1
 				exp_continue
 			}
 		}
 		-re "Invalid job id specified" {
-			send_user "\nFAILURE: Job $job_id not found\n"
+			send_user "\n\033\[31mFAILURE: Job $job_id not found\033\[m\n"
 			set exit_code 1
 			exp_continue
 		}
 		timeout {
-			send_user "\nFAILURE: scontrol not responding\n"
+			send_user "\n\033\[31mFAILURE: scontrol not responding\033\[m\n"
 			set exit_code 1
 		}
 		eof {
@@ -97,17 +97,19 @@ proc inc3_11_3 {} {
 		}
 	}
 
+	send_user "\n\033\[32mJOB is running as expected\033\[m\n"
+
 	# Cancel the job
 	spawn $scancel -v $job_id
 	expect {
 		-re "Invalid job_id" {
-			send_user "\nFAILURE: Error cancelling the job submitted "
-			send_user "to the reservation.  Job $job_id not found\n"
+			send_user "\n\033\[31mFAILURE: Error cancelling the job submitted "
+			send_user "to the reservation.  Job $job_id not found\033\[m\n"
 			set exit_code 1
 			exp_continue
 		}
 		timeout {
-			send_user "\nFAILURE: scancel not responding\n"
+			send_user "\n\033\[31mFAILURE: scancel not responding\033\[m\n"
 			set exit_code 1
 		}
 		eof {

--- a/testsuite/expect/inc3.11.4
+++ b/testsuite/expect/inc3.11.4
@@ -47,7 +47,7 @@ proc inc3_11_4 {} {
 	# Make the reservation
 	set ret_code [create_res "StartTime=now+60minutes Duration=60 NodeCnt=1 User=root" 0]
 	if {$ret_code != 0} {
-		send_user "\nFAILURE: Unable to create a reservation\n"
+		send_user "\n\033\[31mFAILURE: Unable to create a reservation\033\[m\n"
 		set exit_code 1
 	}
 
@@ -58,7 +58,7 @@ proc inc3_11_4 {} {
 		-re "Submitted batch job ($number)" {
 			set job_id $expect_out(1,string)
 			exec $scancel $job_id
-			send_user "\nFAILURE: job submit should have been denied\n"
+			send_user "\n\033\[31mFAILURE: job submit should have been denied\033\[m\n"
 			set exit_code 1
 			exp_continue
 		}
@@ -68,7 +68,7 @@ proc inc3_11_4 {} {
 			exp_continue
 		}
 		timeout {
-			send_user "\nFAILURE: sbatch not responding\n"
+			send_user "\n\033\[31mFAILURE: sbatch not responding\033\[m\n"
 			slow_kill $sbatch_pid
 			set exit_code 1
 		}
@@ -78,12 +78,12 @@ proc inc3_11_4 {} {
 	}
 
 	if {$denied == 0} {
-		send_user "\nFAILURE: Job $job_id should have been rejected "
+		send_user "\n\033\[31mFAILURE: Job $job_id should have been rejected "
 		send_user "from reservation restricted to root.  Expected "
-		send_user "rejection message not given.\n"
+		send_user "rejection message not given.\033\[m\n"
 		set exit_code 1
 	} else {
-		send_user "Expected error, no worries mate.\n"
+		send_user "\033\[32mExpected error, no worries mate.\033\[m\n"
 	}
 	# Delete the reservation
 	set ret_code [delete_res $res_name]

--- a/testsuite/expect/inc3.11.5
+++ b/testsuite/expect/inc3.11.5
@@ -40,7 +40,7 @@ proc inc3_11_5 {} {
 	# Make the reservation
 	set ret_code [create_res "StartTime=now+60minutes Duration=60 Nodes=ALL user=$user_name" 0]
 	if {$ret_code != 0} {
-		send_user "\nFAILURE: Unable to create a valid reservation\n"
+		send_user "\n\033\[31mFAILURE: Unable to create a valid reservation\033\[m\n"
 		exit $ret_code
 	}
 
@@ -49,11 +49,11 @@ proc inc3_11_5 {} {
 	# Test for node reservation conflict
 	set ret_code [create_res "StartTime=now+60minutes Duration=60 NodeCnt=1 user=$user_name" 1]
 	if {$ret_code == 0} {
-		send_user "\nFAILURE: Reservation $test did not fail but should have\n"
+		send_user "\n\033\[31mFAILURE: Reservation $test did not fail but should have\033\[m\n"
 		delete_res $res_name
 		exit 1
 	} else {
-		send_user "Expected error.  You can turn that frown upside-down.\n"
+		send_user "\033\[32mExpected error.  You can turn that frown upside-down.\033\[m\n"
 	}
 
 	# Delete the reservation

--- a/testsuite/expect/inc3.11.6
+++ b/testsuite/expect/inc3.11.6
@@ -40,7 +40,7 @@ proc inc3_11_6 {} {
 	# Make the reservation
 	set ret_code [create_res "StartTime=now+60minutes Duration=60 Nodes=ALL user=$user_name" 0]
 	if {$ret_code != 0} {
-		send_user "\nFAILURE: Unable to create a valid reservation\n"
+		send_user "\n\033\[31mFAILURE: Unable to create a valid reservation\033\[m\n"
 		exit $ret_code
 	}
 
@@ -49,11 +49,11 @@ proc inc3_11_6 {} {
 	# Test for time reservation conflict (front overlap)
 	set ret_code [create_res "StartTime=now+30minutes Duration=60 Nodes=ALL user=$user_name" 1]
 	if {$ret_code == 0} {
-		send_user "\nFAILURE: Reservation $test did not fail but should have\n"
+		send_user "\n\033\[31mFAILURE: Reservation $test did not fail but should have\033\[m\n"
 		delete_res $res_name
 		exit 1
 	} else {
-		send_user "Expected error.  You can turn that frown upside-down.\n"
+		send_user "\033\[32mExpected error.  You can turn that frown upside-down.\033\[m\n"
 	}
 
 	# Delete the reservation
@@ -66,7 +66,7 @@ proc inc3_11_6 {} {
 	# Make the reservation
 	set ret_code [create_res "StartTime=now+30minutes Duration=60 Nodes=ALL user=$user_name" 0]
 	if {$ret_code != 0} {
-		send_user "\nFAILURE: Unable to create a valid reservation\n"
+		send_user "\n\033\[31mFAILURE: Unable to create a valid reservation\033\[m\n"
 		exit $ret_code
 	}
 
@@ -75,11 +75,11 @@ proc inc3_11_6 {} {
 	# Test for time reservation conflict (trail overlap)
 	set ret_code [create_res "StartTime=now+60minutes Duration=60 Nodes=ALL user=$user_name" 1]
 	if {$ret_code == 0} {
-		send_user "\nFAILURE: Reservation $test did not fail but should have\n"
+		send_user "\n\033\[31mFAILURE: Reservation $test did not fail but should have\033\[m\n"
 		delete_res $res_name
 		exit 1
 	} else {
-		send_user "Expected error.  You can turn that frown upside-down.\n"
+		send_user "\033\[32mExpected error.  You can turn that frown upside-down.\033\[m\n"
 	}
 	# Delete the reservation
 	set ret_code [delete_res $res_name_save]
@@ -92,6 +92,6 @@ proc inc3_11_6 {} {
 	exec $bin_rm -f $file_in
 
 	if {$exit_code == 0} {
-		send_user "\nSUCCESS\n"
+		send_user "\n\033\[32mSUCCESS\033\[m\n"
 	}
 }

--- a/testsuite/expect/inc3.11.7
+++ b/testsuite/expect/inc3.11.7
@@ -2,7 +2,7 @@
 # Purpose: Test of SLURM functionality
 #          to be called from test3.11
 #	   Several cases for core based reservations 
-#          
+#          Pluging select/cons_res needed
 #
 ############################################################################
 # Copyright (C) 2009 Lawrence Livermore National Security

--- a/testsuite/expect/inc3.11.8
+++ b/testsuite/expect/inc3.11.8
@@ -2,7 +2,7 @@
 # Purpose: Test of SLURM functionality
 #          to be called from test3.11
 #	   Several cases for core based reservations 
-#          
+#          Pluging select/cons_res needed
 #
 ############################################################################
 # Copyright (C) 2009 Lawrence Livermore National Security
@@ -39,7 +39,7 @@ proc inc3_11_8 {} {
 	set num_nodes [available_nodes $def_partition]
 	set core_res_num [ expr ($cores_per_node / 2) ]
 
-	send_user "\n+++++ STARTING TEST 7 +++++\n"
+	send_user "\n+++++ STARTING TEST 8 +++++\n"
 
 	# Make the job script
 	exec $bin_rm -f $file_in

--- a/testsuite/expect/test3.11
+++ b/testsuite/expect/test3.11
@@ -38,6 +38,8 @@ source ./inc3.11.3
 source ./inc3.11.4
 source ./inc3.11.5
 source ./inc3.11.6
+source ./inc3.11.7
+source ./inc3.11.8
 
 
 
@@ -63,6 +65,9 @@ proc create_res { res_params failure_expected } {
 	global scontrol
 	global alpha_numeric_under
 	global res_name
+	global res_nodes
+	global res_nodecnt
+	global res_corecnt
 
 	set ret_code 0
 	set res_name ""
@@ -93,7 +98,7 @@ proc create_res { res_params failure_expected } {
 			exp_continue
 		}
 		timeout {
-			send_user "\nFAILURE: scontrol not responding\n"
+			send_user "\n\033\[31mFAILURE: scontrol not responding\033\[m\n"
 			set ret_code 1
 		}
 		eof {
@@ -134,6 +139,18 @@ proc create_res { res_params failure_expected } {
 				send_user "with:  $res_params\n"
 			}
 			set ret_code 1
+			exp_continue
+		}
+		-re "Nodes=($alpha_numeric_under)" {
+			set res_nodes $expect_out(1,string)
+			exp_continue
+		}
+		-re "NodeCnt=($alpha_numeric_under)" {
+			set res_nodecnt $expect_out(1,string)
+			exp_continue
+		}
+		-re "CoreCnt=($alpha_numeric_under)" {
+			set res_corecnt $expect_out(1,string)
 			exp_continue
 		}
 		timeout {
@@ -276,22 +293,44 @@ expect {
 }
 
 
+set cons_res_actived 0
+spawn $scontrol show config
+expect {
+	-re "select/cons_res" {
+		set cons_res_actived 1
+	}
+	timeout {
+		send_user "\nFAILURE: scontrol not responding\n"
+		set exit_code 1
+	}
+	eof {
+		wait
+	}
+}
+
 # Start Test 1
-inc3_11_1
+#inc3_11_1
 
 # Start Test 2
-inc3_11_2
+#inc3_11_2
 
 # Start Test 3
-inc3_11_3
+#inc3_11_3
 
 # Start Test 4
-inc3_11_4
+#inc3_11_4
 
 # Start Test 5
-inc3_11_5
+#inc3_11_5
 
 # Start Test 6
-inc3_11_6
+#inc3_11_6
 
+if {$cons_res_actived == 1} {
+# Start Test 7
+inc3_11_7
+
+# Start Test 8
+inc3_11_8
+}
 exit $exit_code


### PR DESCRIPTION
This is first  patch for overcoming limitations with current core based reservations. Now nodes with available cores at reservation start time can be used.

I've added some extra tests for testing this kind of reservations.
