### PR TITLE
Wrong number of fields listed in the output of sacct -d

### DIFF
--- a/src/sacct/options.c
+++ b/src/sacct/options.c
@@ -1263,7 +1263,7 @@ void do_dump(void)
 			       job->blockid,	/* block id */
 			       "-");	/* reserved 1 */
 
-			printf("JOB_START 1 16 %d %d %s %d %d %d %s %s\n",
+			printf("JOB_START 1 17 %d %d %s %d %d %d %s %s\n",
 			       job->uid,
 			       job->gid,
 			       job->jobname,
@@ -1293,7 +1293,7 @@ void do_dump(void)
 				step->end = job->end;
 
 			gmtime_r(&step->end, &ts);
-			printf("JOB_STEP 1 50 %u %04d%02d%02d%02d%02d%02d ",
+			printf("JOB_STEP 1 41 %u %04d%02d%02d%02d%02d%02d ",
 			       step->stepid,
 			       1900+(ts.tm_year), 1+(ts.tm_mon), ts.tm_mday,
 			            ts.tm_hour, ts.tm_min, ts.tm_sec);
@@ -1350,7 +1350,7 @@ void do_dump(void)
 			       job->blockid,	/* block id */
 			       "-");	/* reserved 1 */
 			gmtime_r(&job->end, &ts);
-			printf("JOB_TERMINATED 1 50 %d ",
+			printf("JOB_TERMINATED 1 42 %d ",
 			       job->elapsed);
 			printf("%04d%02d%02d%02d%02d%02d ",
 			1900+(ts.tm_year), 1+(ts.tm_mon), ts.tm_mday,


### PR DESCRIPTION
When running "sacct -d" commands, the different output lines are sets of records whose 9th position is  the total number of fields that the record contains. This number serves at the same time as a version number for this record.
In the current head, the three numbers for the three different kinds of lines have wrong values, in some cases because the number is too low, and in others because it is too high.
This patch solves this problem by just putting the right numbers.
I don't know which is the policy for the "Job record version" field, maybe it should be also upgraded :-?
