### PR TITLE
Fix makefile comment to reflect plugin name

### DIFF
--- a/src/plugins/proctrack/cgroup/Makefile.am
+++ b/src/plugins/proctrack/cgroup/Makefile.am
@@ -1,4 +1,4 @@
-# Makefile for proctrack/linuxproc plugin
+# Makefile for proctrack/cgroup plugin
 
 AUTOMAKE_OPTIONS = foreign
 


### PR DESCRIPTION
Minor name change in a comment.
