### PR TITLE
Fix broken build when HAVE_READLINE is false

### DIFF
--- a/src/sreport/sreport.c
+++ b/src/sreport/sreport.c
@@ -223,7 +223,7 @@ static char *_getline(const char *prompt)
 		len++;
 	line = malloc (len * sizeof(char));
 	if (!line)
-		return NULL
+		return NULL;
 	return strncpy(line, buf, len);
 }
 #endif


### PR DESCRIPTION
I committed a change required to build on a Centos 6.0 box. There is a missing semi-colon in sreport.c that is covered by a #if !HAVE_READLINE, so it probably doesn't show up on your regular builds.

The change is trivial - just thought I'd pass it along.
