### PR TITLE
Fixed topology.conf example so it matches the image

### DIFF
--- a/doc/html/topology.shtml
+++ b/doc/html/topology.shtml
@@ -130,6 +130,9 @@ SwitchName=s1 Nodes=tux[4-7]
 SwitchName=s2 Nodes=tux[8-11]
 SwitchName=s3 Nodes=tux[12-15]
 SwitchName=s4 Switches=s[0-3]
+SwitchName=s5 Switches=s[0-3]
+SwitchName=s6 Switches=s[0-3]
+SwitchName=s7 Switches=s[0-3]
 </pre>
 
 <p style="text-align:center;">Last modified 27 March 2012</p>


### PR DESCRIPTION
Came across this when I tried to use it as sample data. The example topology file doesn't match the image it refers to.

For example, here's the original topology:

![Original Topo](http://i.imgur.com/DMzqyFO.png)

And after this pull request:

![New Topo](http://i.imgur.com/68ke388.png)
