### PR TITLE
Add username in filename pattern

### DIFF
--- a/doc/man/man1/sbatch.1
+++ b/doc/man/man1/sbatch.1
@@ -541,6 +541,9 @@ Job allocation number.
 \fB%N\fR
 Node name.  Only one file is created, so %N will be replaced by the name of the
 first node in the job, which is the one that runs the script.
+.TP
+\fB%u\fR
+User name.
 .RE
 
 .TP

--- a/src/srun/libsrun/fname.c
+++ b/src/srun/libsrun/fname.c
@@ -171,6 +171,12 @@ fname_create(srun_job_t *job, char *format)
 				 q = ++p;
 				 break;
 
+			 case 'u':  /* '%u' => username       */
+				xmemcat(name, q, p - 1);
+				xstrfmtcat(name, "%s", opt.user);
+				q = ++p;
+				break;
+
 			 default:
 				 break;
 			}


### PR DESCRIPTION
Added the username to the filename pattern in the batch script.

This simplify the share of the same batch script from multiple users.
