### PR TITLE
Have qsub.pl pass along return code from sbatch/salloc

### DIFF
--- a/contribs/torque/qsub.pl
+++ b/contribs/torque/qsub.pl
@@ -210,7 +210,8 @@ $command .= " -C $additional_attributes" if $additional_attributes;
 
 $command .= " $script";
 
-system($command);
+my $ret = system($command);
+exit ($ret >> 8);
 
 
 sub parse_resource_list {


### PR DESCRIPTION
We have some scripts that use the TORQUE wrappers for SLURM. It would be helpful to have error codes passed back from sbatch/salloc.
