### PR TITLE
Default share partition behavior for select/cons_res

### DIFF
--- a/src/plugins/select/cons_res/select_cons_res.c
+++ b/src/plugins/select/cons_res/select_cons_res.c
@@ -1436,8 +1436,9 @@ static uint16_t _get_job_node_req(struct job_record *job_ptr)
 		/* user has requested exclusive nodes */
 		return NODE_CR_RESERVED;
 
-	if ((max_share > 1) && (job_ptr->details->shared == 1))
-		/* part allows sharing, and the user has requested it */
+	if (max_share > 1)
+		/* part allows sharing, the user may have requested it
+		 * but otherwise is assumed default option */
 		return NODE_CR_AVAILABLE;
 
 	return NODE_CR_ONE_ROW;


### PR DESCRIPTION
Fix the sharing options for select/cons_res to adjust to documentation.

Specifically, given a partition is set to allow over-subscription of resources and a user does not request exclusive nor shared access to them, set the job sharing properties as NODE_CR_AVAILABLE as the default option regardless of the presence of the --share option at submission time.
