### PR TITLE
include the cpu_load value in the perlapi

### DIFF
--- a/contribs/perlapi/libslurm/perl/node.c
+++ b/contribs/perlapi/libslurm/perl/node.c
@@ -61,6 +61,7 @@ node_info_to_hv(node_info_t *node_info, uint16_t node_scaling, HV *hv)
 	STORE_FIELD(hv, node_info, sockets, uint16_t);
 	STORE_FIELD(hv, node_info, threads, uint16_t);
 	STORE_FIELD(hv, node_info, tmp_disk, uint32_t);
+  STORE_FIELD(hv, node_info, cpu_load, uint32_t);
 
 	slurm_get_select_nodeinfo(node_info->select_nodeinfo,
 				  SELECT_NODEDATA_SUBCNT,
@@ -118,6 +119,7 @@ hv_to_node_info(HV *hv, node_info_t *node_info)
 	FETCH_FIELD(hv, node_info, threads, uint16_t, TRUE);
 	FETCH_FIELD(hv, node_info, tmp_disk, uint32_t, TRUE);
 	FETCH_FIELD(hv, node_info, weight, uint32_t, TRUE);
+  FETCH_FIELD(hv, node_info, cpu_load, uint32_t, TRUE);
 	FETCH_PTR_FIELD(hv, node_info, select_nodeinfo, "Slurm::dynamic_plugin_data_t", TRUE);
 	return 0;
 }


### PR DESCRIPTION
Quick patch to include the cpu_load values in the perlapi node info.
