### PR TITLE
Log why a suspend or resume program is invalid

### DIFF
--- a/src/slurmctld/power_save.c
+++ b/src/slurmctld/power_save.c
@@ -552,24 +552,22 @@ static bool _valid_prog(char *file_name)
 	struct stat buf;
 
 	if (file_name[0] != '/') {
-		debug("power_save program %s not absolute pathname",
-		     file_name);
+		error("power_save program %s not absolute pathname", file_name);
 		return false;
 	}
 
 	if (access(file_name, X_OK) != 0) {
-		debug("power_save program %s not executable", file_name);
+		error("power_save program %s not executable", file_name);
 		return false;
 	}
 
 	if (stat(file_name, &buf)) {
-		debug("power_save program %s not found", file_name);
+		error("power_save program %s not found", file_name);
 		return false;
 	}
 	if (buf.st_mode & 022) {
-		debug("power_save program %s has group or "
-		      "world write permission",
-		      file_name);
+		error("power_save program %s has group or "
+		      "world write permission", file_name);
 		return false;
 	}
 


### PR DESCRIPTION
We had a production outage today due to accidentally setting the suspend program to group writable. Having the reason the program was invalid displayed in the error message would have reduced the length of our downtime.

I am not sure if this is stylistically in tune with slurm, so if not please let me know and I'll update the patch.
