### PR TITLE
squeue spends an excessive amount of time converting uids to usernames

### DIFF
--- a/src/squeue/print.c
+++ b/src/squeue/print.c
@@ -544,9 +544,8 @@ int _print_job_user_name(job_info_t * job, int width, bool right, char* suffix)
 	if (job == NULL)	/* Print the Header instead */
 		_print_str("USER", width, right, true);
 	else {
-		char *uname = uid_to_string((uid_t) job->user_id);
+		char *uname = uid_to_string_cached((uid_t) job->user_id);
 		_print_str(uname, width, right, true);
-		xfree(uname);
 	}
 	if (suffix)
 		printf("%s", suffix);
@@ -1476,7 +1475,6 @@ int _print_step_user_name(job_step_info_t * step, int width, bool right,
 	else {
 		char *uname = uid_to_string((uid_t) step->user_id);
 		_print_str(uname, width, right, true);
-		xfree(uname);
 	}
 	if (suffix)
 		printf("%s", suffix);

--- a/src/squeue/sort.c
+++ b/src/squeue/sort.c
@@ -758,11 +758,9 @@ static int _sort_job_by_user_name(void *void1, void *void2)
 
 	_get_job_info_from_void(&job1, &job2, void1, void2);
 
-	name1 = uid_to_string((uid_t) job1->user_id);
-	name2 = uid_to_string((uid_t) job2->user_id);
+	name1 = uid_to_string_cached((uid_t) job1->user_id);
+	name2 = uid_to_string_cached((uid_t) job2->user_id);
 	diff = strcmp(name1, name2);
-	xfree(name1);
-	xfree(name2);
 
 	if (reverse_order)
 		diff = -diff;
@@ -982,8 +980,6 @@ static int _sort_step_by_user_name(void *void1, void *void2)
 	name1 = uid_to_string((uid_t) step1->user_id);
 	name2 = uid_to_string((uid_t) step2->user_id);
 	diff = strcmp(name1, name2);
-	xfree(name1);
-	xfree(name2);
 
 	if (reverse_order)
 		diff = -diff;

--- a/src/squeue/squeue.h
+++ b/src/squeue/squeue.h
@@ -120,6 +120,8 @@ struct squeue_parameters {
 
 extern struct squeue_parameters params;
 
+extern char *uid_to_string_cached(uid_t);
+
 extern void parse_command_line( int argc, char* argv[] );
 extern int  parse_format( char* format );
 extern void sort_job_list( List job_list );


### PR DESCRIPTION
`squeue` has to convert `uid_t` to a `char*` username a _lot_. Once for every line of output(with the default format) and once for _every_ comparison when sorting by username. This causes multiple system calls to open and read `/etc/passwd` on standard systems and on my system running YP there were 17 unnecessary entries in strace per line in the output.

You might wan't to reimplement your own version. Mine is brain dead simple, sorts the array for every new entry and never attempts to free memory for usernames.

Since our system is running YP/NIS it is probably especially bad, but here are some quick timings:

```
[aeh@fe2 bin]$ time squeue | wc -l
2300

real    0m0.451s
user    0m0.061s
sys 0m0.056s
[aeh@fe2 bin]$ time patched_squeue | wc -l
2300

real    0m0.042s
user    0m0.018s
sys 0m0.005s
[aeh@fe2 bin]$ time squeue --sort=u | wc -l
2300

real    0m4.811s
user    0m0.408s
sys 0m0.615s
[aeh@fe2 bin]$ time patched_squeue --sort=u | wc -l
2300

real    0m0.048s
user    0m0.019s
sys 0m0.006s
```
