### PR TITLE
remove crufty(?) log message

### DIFF
--- a/src/slurmctld/job_mgr.c
+++ b/src/slurmctld/job_mgr.c
@@ -4027,7 +4027,6 @@ static int _part_access_check(struct part_record *part_ptr,
 	}
 
 	if (slurmctld_conf.enforce_part_limits) {
-		info("checking here");
 		if ((rc = part_policy_valid_acct(part_ptr, acct))
 		    != SLURM_SUCCESS)
 			goto fini;


### PR DESCRIPTION
This log message seems like debugging cruft, and it's generating a fair number of log entries:

[jwm@holy-slurm01:pts/4 ~> sudo grep -c '^[2014-06-30T.*checking here' /var/slurmd/log/slurmctld.log  
90714
[jwm@holy-slurm01:pts/4 ~> sudo grep -c '^[2014-06-30T' /var/slurmd/log/slurmctld.log
444666
