### PR TITLE
reset last_proc_req_start on 'sdiag --reset', too

### DIFF
--- a/src/slurmctld/controller.c
+++ b/src/slurmctld/controller.c
@@ -1649,19 +1649,12 @@ static void *_slurmctld_background(void *no_data)
 			_accounting_cluster_ready();
 		}
 
+		/* Stats will reset at midnight (approx) local time. */
 		if (last_proc_req_start == 0) {
-			/* Stats will reset at midnight (aprox).
-			 * Uhmmm... UTC time?... It is  not so important.
-			 * Just resetting during the night */
 			last_proc_req_start = now;
-			next_stats_reset = last_proc_req_start -
-					   (last_proc_req_start % 86400) +
-					   86400;
+			next_stats_reset = now - (now % 86400) + 86400;
 		}
-
-		if ((next_stats_reset > 0) && (now > next_stats_reset)) {
-			/* Resetting stats values */
-			last_proc_req_start = now;
+		if (now >= next_stats_reset) {
 			next_stats_reset = now - (now % 86400) + 86400;
 			reset_stats(0);
 		}

--- a/src/slurmctld/statistics.c
+++ b/src/slurmctld/statistics.c
@@ -155,4 +155,6 @@ extern void reset_stats(int level)
 	slurmctld_diag_stats.bf_last_depth = 0;
 	slurmctld_diag_stats.bf_last_depth_try = 0;
 	slurmctld_diag_stats.bf_active = 0;
+
+    last_proc_req_start = time(NULL);
 }


### PR DESCRIPTION
The 'data since' counter in sdiag(1) output wasn't being reset after 'sdiag -r'. This patch fixes that, and makes the logic in slurmctld/controller.c a little more readable.
