### PR TITLE
Fix typo: SlurmctlDebug -> SlurmctldDebug

### DIFF
--- a/doc/man/man5/slurm.conf.5
+++ b/doc/man/man5/slurm.conf.5
@@ -2667,7 +2667,7 @@ and \fBSlurmSchedLogLevel\fR parameters.
 .TP
 \fBSlurmSchedLogLevel\fR
 The initial level of scheduling event logging, similar to the
-\fBSlurmctlDebug\fR parameter used to control the initial level of
+\fBSlurmctldDebug\fR parameter used to control the initial level of
 \fBslurmctld\fR logging.
 Valid values for \fBSlurmSchedLogLevel\fR are "0" (scheduler logging
 disabled) and "1" (scheduler logging enabled).


### PR DESCRIPTION
Typo in config parameter name, SlurmctlDebug should be SlurmctldDebug
