### PR TITLE
Add Swedish 'fika' (3PM) as valid input for time

### DIFF
--- a/src/common/parse_time.c
+++ b/src/common/parse_time.c
@@ -323,7 +323,7 @@ static int _get_date(char *time_str, int *pos, int *month, int *mday, int *year)
 /* Convert string to equivalent time value
  * input formats:
  *   today or tomorrow
- *   midnight, noon, teatime (4PM)
+ *   midnight, noon, fika (3PM), teatime (4PM)
  *   HH:MM[:SS] [AM|PM]
  *   MMDD[YY] or MM/DD[/YY] or MM.DD[.YY]
  *   MM/DD[/YY]-HH:MM[:SS]
@@ -385,6 +385,13 @@ extern time_t parse_time(char *time_str, int past)
 		}
 		if (strncasecmp(time_str+pos, "noon", 4) == 0) {
 			hour   = 12;
+			minute = 0;
+			second = 0;
+			pos += 3;
+			continue;
+		}
+		if (strncasecmp(time_str+pos, "fika", 4) == 0) {
+			hour   = 15;
 			minute = 0;
 			second = 0;
 			pos += 3;


### PR DESCRIPTION
At work in Sweden we often fika (coffee+buns and what have u) at 3PM. I sometimes accidentally give a start time of 'teatime', so when I return from 'fika' I see my job's just getting started. This fix should make life even easier for the Swedes.
