### PR TITLE
eio: remove shutdown'ed connections from eio list.

### DIFF
--- a/src/common/eio.c
+++ b/src/common/eio.c
@@ -368,6 +368,13 @@ _poll_setup_pollfds(struct pollfd *pfds, eio_obj_t *map[], List l)
 	}
 
 	while ((obj = list_next(i))) {
+		// cleanup connection list
+		if( obj->shutdown == true ){
+			eio_obj_t *obj1  = list_remove(i);
+			xassert( obj1 == obj );
+			xfree(obj);
+			continue;
+		}
 		writable = _is_writable(obj);
 		readable = _is_readable(obj);
 		if (writable && readable) {


### PR DESCRIPTION
I am not sure that I have completely correct understanding of eio so this PR can be viewed as RFC.
With current implementation of eio I was unable to find the place in the code where stalled connections are removed from the list. Current use cases in SLURM are fine with this approach since new requests are usually handled inside the callback in following manner:
1. fd = accept();
2. process(fd);
3. close(fd);
But with PMIx we try to benefit from nonblocking connections and if the message can't be read right at accept time it's processing will be deferred and fd will be added into the eio handler. Once message is received fd can be closed and I don't need this connection in eio list anymore.
The PR provides my vision of a fix for that problem.
