### PR TITLE
Display large unsigned jobid's in smap

### DIFF
--- a/src/smap/job_functions.c
+++ b/src/smap/job_functions.c
@@ -208,7 +208,7 @@ static void _print_header_job(void)
 		main_xcord += 3;
 		mvwprintw(text_win, main_ycord,
 			  main_xcord, "JOBID");
-		main_xcord += 8;
+		main_xcord += 12;
 		mvwprintw(text_win, main_ycord,
 			  main_xcord, "PARTITION");
 		main_xcord += 10;
@@ -321,8 +321,8 @@ static int _print_text_job(job_info_t * job_ptr)
 			  main_xcord, "%c", job_ptr->num_cpus);
 		main_xcord += 3;
 		mvwprintw(text_win, main_ycord,
-			  main_xcord, "%d", job_ptr->job_id);
-		main_xcord += 8;
+			  main_xcord, "%u", job_ptr->job_id);
+		main_xcord += 12;
 		mvwprintw(text_win, main_ycord,
 			  main_xcord, "%.10s", job_ptr->partition);
 		main_xcord += 10;


### PR DESCRIPTION
Sufficiently large jobids (greater than INT_MAX) are displayed
incorrectly by smap. Example...

```
$ which smap
/usr/bin/smap
$ smap --version
slurm 14.11.1
$ smap -i 15

┌────────────────────────────────────────────────────────────────────────────────────────┐
│AAAA                                                                                    │
│                                                                                        │
│                                                                                        │
│                                                                                        │
│                                                                                        │
│                                                                                        │
│                                                                                        │
│                                                                                        │
└────────────────────────────────────────────────────────────────────────────────────────┘
┌────────────────────────────────────────────────────────────────────────────────────────┐
│Mon Dec 08 22:33:23 2014                                                                │
│ID JOBID   PARTITION USER     NAME  ST      TIME NODES NODELIST                         │
│A  -1342806debug     tcooper  imb   R   00:01:41     4 ccn-1-[11-14]                    │
│B  -1342806debug     tcooper  hpl   PD  00:00:00     4 waiting...                       │
│                                                                                        │
│                                                                                        │
│                                                                                        │
│                                                                                        │
│                                                                                        │
│                                                                                        │
│                                                                                        │
│                                                                                        │
└────────────────────────────────────────────────────────────────────────────────────────┘

```

Change output of jobid by smap to support uint32_t
values and shift remaining colums appropriately to the right. Example...

```
$ /home/tcooper/slurm/bin/smap --version
slurm 14.11.1

$ /home/tcooper/slurm/bin/smap -i 15

┌────────────────────────────────────────────────────────────────────────────────────────┐
│AAAA                                                                                    │
│                                                                                        │
│                                                                                        │
│                                                                                        │
│                                                                                        │
│                                                                                        │
│                                                                                        │
│                                                                                        │
└────────────────────────────────────────────────────────────────────────────────────────┘
┌────────────────────────────────────────────────────────────────────────────────────────┐
│Mon Dec 08 22:33:40 2014                                                                │
│ID JOBID       PARTITION USER     NAME      ST      TIME NODES NODELIST                 │
│A  4160686661  debug     tcooper  imb       R   00:01:58     4 ccn-1-[11-14]            │
│B  4160686662  debug     tcooper  hpl       PD  00:00:00     4 waiting...               │
│                                                                                        │
│                                                                                        │
│                                                                                        │
│                                                                                        │
│                                                                                        │
│                                                                                        │
│                                                                                        │
│                                                                                        │
└────────────────────────────────────────────────────────────────────────────────────────┘
```
