### PR TITLE
Replacing python with python2

### DIFF
--- a/doc/html/shtml2html.py
+++ b/doc/html/shtml2html.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import re
 import sys


### PR DESCRIPTION
Many systems nowadays interpret "#!/usr/bin/env python" as python 3.X however this file must be run with python2 if I am not wrong. Hence replacing "#!/usr/bin/env python" with "#!/usr/bin/env python2".