### PR TITLE
Fix systemd paths in spec file

### DIFF
--- a/slurm.spec
+++ b/slurm.spec
@@ -580,10 +580,10 @@ test -f $RPM_BUILD_ROOT/etc/init.d/slurm			&&
   echo /etc/init.d/slurm				>> $LIST
 test -f $RPM_BUILD_ROOT/usr/sbin/rcslurm			&&
   echo /usr/sbin/rcslurm				>> $LIST
-test -f $RPM_BUILD_ROOT/lib/systemd/system/slurmctld.service	&&
-  echo /lib/systemd/system/slurmctld.service		>> $LIST
-test -f $RPM_BUILD_ROOT/lib/systemd/system/slurmd.service	&&
-  echo /lib/systemd/system/slurmd.service		>> $LIST
+test -f $RPM_BUILD_ROOT/usr/lib/systemd/system/slurmctld.service	&&
+  echo /usr/lib/systemd/system/slurmctld.service		>> $LIST
+test -f $RPM_BUILD_ROOT/usr/lib/systemd/system/slurmd.service	&&
+  echo /usr/lib/systemd/system/slurmd.service		>> $LIST
 test -f $RPM_BUILD_ROOT/%{_bindir}/netloc_to_topology		&&
   echo %{_bindir}/netloc_to_topology			>> $LIST
 
@@ -657,8 +657,8 @@ test -f $RPM_BUILD_ROOT/etc/init.d/slurmdbd			&&
   echo /etc/init.d/slurmdbd				>> $LIST
 test -f $RPM_BUILD_ROOT/usr/sbin/rcslurmdbd			&&
   echo /usr/sbin/rcslurmdbd				>> $LIST
-test -f $RPM_BUILD_ROOT/lib/systemd/system/slurmdbd.service	&&
-  echo /lib/systemd/system/slurmdbd.service		>> $LIST
+test -f $RPM_BUILD_ROOT/usr/lib/systemd/system/slurmdbd.service	&&
+  echo /usr/lib/systemd/system/slurmdbd.service		>> $LIST
 
 LIST=./sql.files
 touch $LIST


### PR DESCRIPTION
Systemd service files were being created in the right place /usr/lib/systemd, but the test for their presence was looking in /lib, not /usr/lib.