### PR TITLE
Fix systemd startup files to use default values for pid files

### DIFF
--- a/etc/slurmctld.service.in
+++ b/etc/slurmctld.service.in
@@ -6,7 +6,7 @@ ConditionPathExists=@sysconfdir@/slurm.conf
 [Service]
 Type=forking
 ExecStart=@sbindir@/slurmctld
-PIDFile=/var/run/slurm/slurmctld.pid
+PIDFile=/var/run/slurmctld.pid
 
 [Install]
 WantedBy=multi-user.target

--- a/etc/slurmd.service.in
+++ b/etc/slurmd.service.in
@@ -6,7 +6,7 @@ ConditionPathExists=@sysconfdir@/slurm.conf
 [Service]
 Type=forking
 ExecStart=@sbindir@/slurmd
-PIDFile=/var/run/slurm/slurmd.pid
+PIDFile=/var/run/slurmd.pid
 
 [Install]
 WantedBy=multi-user.target

--- a/etc/slurmdbd.service.in
+++ b/etc/slurmdbd.service.in
@@ -6,7 +6,7 @@ ConditionPathExists=@sysconfdir@/slurmdbd.conf
 [Service]
 Type=forking
 ExecStart=@sbindir@/slurmdbd
-PIDFile=/var/run/slurm/slurmdbd.pid
+PIDFile=/var/run/slurmdbd.pid
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Previously the systemd startup files used a non-default location for the pid files in /var/run/slurm/. This makes patch makes them use the default location in /var/run/.

In RHEL7/Centes7 /var/run is by default a tmpfs, i.e., if we want to keep using /var/run/slurm/ we need to somehow add extra logic to create the /var/spool/slurm directory after each boot.