### PR TITLE
Improve cpu profiling values

### DIFF
--- a/src/common/slurm_jobacct_gather.h
+++ b/src/common/slurm_jobacct_gather.h
@@ -115,11 +115,11 @@ struct jobacctinfo {
 			     (used to figure out ave later) */
 	uint32_t min_cpu; /* min cpu time */
 	jobacct_id_t min_cpu_id; /* contains which task it was on */
-	uint32_t tot_cpu; /* total cpu time(used to figure out ave later) */
+	double tot_cpu; /* total cpu time(used to figure out ave later) */
 	uint32_t act_cpufreq; /* actual cpu frequency */
 	acct_gather_energy_t energy;
-	uint32_t last_total_cputime;
-	uint32_t this_sampled_cputime;
+	double last_total_cputime;
+	double this_sampled_cputime;
 	uint32_t current_weighted_freq;
 	uint32_t current_weighted_power;
 	double max_disk_read; /* max disk read data */

--- a/src/plugins/acct_gather_profile/hdf5/hdf5_api.c
+++ b/src/plugins/acct_gather_profile/hdf5/hdf5_api.c
@@ -1108,7 +1108,7 @@ static hid_t _task_create_memory_datatype(void)
 	MEM_ADD_DATE_TIME(mtyp_task, "Date_Time", profile_task_t, tod);
 	MEM_ADD_UINT64(mtyp_task, "Time", profile_task_t, time);
 	MEM_ADD_UINT64(mtyp_task, "CPU_Frequency", profile_task_t, cpu_freq);
-	MEM_ADD_UINT64(mtyp_task, "CPU_Time", profile_task_t, cpu_time);
+	MEM_ADD_DBL(mtyp_task, "CPU_Time", profile_task_t, cpu_time);
 	MEM_ADD_DBL(mtyp_task, "CPU_Utilization",
 		    profile_task_t, cpu_utilization);
 	MEM_ADD_UINT64(mtyp_task, "RSS", profile_task_t, rss);
@@ -1131,7 +1131,7 @@ static hid_t _task_create_file_datatype(void)
 	FILE_ADD_DATE_TIME(ftyp_task, "Date_Time", 0);
 	FILE_ADD_UINT64(ftyp_task, "Time");
 	FILE_ADD_UINT64(ftyp_task, "CPU_Frequency");
-	FILE_ADD_UINT64(ftyp_task, "CPU_Time");
+	FILE_ADD_DBL(ftyp_task, "CPU_Time");
 	FILE_ADD_DBL(ftyp_task, "CPU_Utilization");
 	FILE_ADD_UINT64(ftyp_task, "RSS");
 	FILE_ADD_UINT64(ftyp_task, "VM_Size");
@@ -1161,13 +1161,13 @@ static hid_t _task_s_create_memory_datatype(void)
 		       cpu_freq.max);
 	MEM_ADD_UINT64(mtyp_task, "Total CPU Frequency", profile_task_s_t,
 		       cpu_freq.total);
-	MEM_ADD_UINT64(mtyp_task, "Min CPU Time", profile_task_s_t,
+	MEM_ADD_DBL(mtyp_task, "Min CPU Time", profile_task_s_t,
 		       cpu_time.min);
-	MEM_ADD_UINT64(mtyp_task, "Ave CPU Time", profile_task_s_t,
+	MEM_ADD_DBL(mtyp_task, "Ave CPU Time", profile_task_s_t,
 		       cpu_time.ave);
-	MEM_ADD_UINT64(mtyp_task, "Max CPU Time", profile_task_s_t,
+	MEM_ADD_DBL(mtyp_task, "Max CPU Time", profile_task_s_t,
 		       cpu_time.max);
-	MEM_ADD_UINT64(mtyp_task, "Total CPU Time", profile_task_s_t,
+	MEM_ADD_DBL(mtyp_task, "Total CPU Time", profile_task_s_t,
 		       cpu_time.total);
 	MEM_ADD_DBL(mtyp_task, "Min CPU Utilization", profile_task_s_t,
 		    cpu_utilization.min);
@@ -1224,10 +1224,10 @@ static hid_t _task_s_create_file_datatype(void)
 	FILE_ADD_UINT64(ftyp_task, "Ave CPU Frequency");
 	FILE_ADD_UINT64(ftyp_task, "Max CPU Frequency");
 	FILE_ADD_UINT64(ftyp_task, "Total CPU Frequency");
-	FILE_ADD_UINT64(ftyp_task, "Min CPU Time");
-	FILE_ADD_UINT64(ftyp_task, "Ave CPU Time");
-	FILE_ADD_UINT64(ftyp_task, "Max CPU Time");
-	FILE_ADD_UINT64(ftyp_task, "Total CPU Time");
+	FILE_ADD_DBL(ftyp_task, "Min CPU Time");
+	FILE_ADD_DBL(ftyp_task, "Ave CPU Time");
+	FILE_ADD_DBL(ftyp_task, "Max CPU Time");
+	FILE_ADD_DBL(ftyp_task, "Total CPU Time");
 	FILE_ADD_DBL(ftyp_task, "Min CPU Utilization");
 	FILE_ADD_DBL(ftyp_task, "Ave CPU Utilization");
 	FILE_ADD_DBL(ftyp_task, "Max CPU Utilization");
@@ -1428,7 +1428,7 @@ static void _task_extract_series(
 	}
 	n_items = size_data / sizeof(profile_task_t);
 	for (ix=0; ix < n_items; ix++) {
-		fprintf(fp,"%d,%d,%s,%s,%s,%ld,%ld,%ld,%.3f",
+		fprintf(fp,"%d,%d,%s,%s,%s,%ld,%ld,%.3f,%.3f",
 			job, step, node, series,
 			task_data[ix].tod, task_data[ix].time,
 			task_data[ix].cpu_freq,
@@ -1465,7 +1465,7 @@ static void _task_extract_total(
 	fprintf(fp, "%d,%d,%s,%s,%s,%ld", job, step, node, series,
 		task_data->start_time, task_data->elapsed_time);
 	PUT_UINT_SUM(fp, task_data->cpu_freq, ",");
-	PUT_UINT_SUM(fp, task_data->cpu_time, ",");
+	PUT_DBL_SUM(fp, task_data->cpu_time, ",");
 	PUT_DBL_SUM(fp, task_data->cpu_utilization, ",");
 	PUT_UINT_SUM(fp, task_data->rss, ",");
 	PUT_UINT_SUM(fp, task_data->vm_size, ",");

--- a/src/plugins/acct_gather_profile/hdf5/hdf5_api.h
+++ b/src/plugins/acct_gather_profile/hdf5/hdf5_api.h
@@ -188,7 +188,7 @@ typedef struct profile_task {
 	char		tod[TOD_LEN];	// Not used in node-step
 	time_t		time;
 	uint64_t	cpu_freq;
-	uint64_t	cpu_time;
+	double		cpu_time;
 	double		cpu_utilization;
 	uint64_t	rss;
 	uint64_t	vm_size;
@@ -201,7 +201,7 @@ typedef struct profile_task_s {
 	char		start_time[TOD_LEN];
 	uint64_t	elapsed_time;
 	prof_uint_sum_t	cpu_freq;
-	prof_uint_sum_t cpu_time;
+	prof_dbl_sum_t cpu_time;
 	prof_dbl_sum_t 	cpu_utilization;
 	prof_uint_sum_t rss;
 	prof_uint_sum_t vm_size;

--- a/src/plugins/jobacct_gather/common/common_jag.c
+++ b/src/plugins/jobacct_gather/common/common_jag.c
@@ -728,7 +728,7 @@ extern void jag_common_poll_data(
 		itr2 = list_iterator_create(prec_list);
 		while ((prec = list_next(itr2))) {
 			if (prec->pid == jobacct->pid) {
-				uint32_t cpu_calc;
+				double cpu_calc;
 #if _DEBUG
 				info("pid:%u ppid:%u rss:%d KB",
 				     prec->pid, prec->ppid, prec->rss);
@@ -737,7 +737,7 @@ extern void jag_common_poll_data(
 				if (callbacks->get_offspring_data)
 					(*(callbacks->get_offspring_data))
 						(prec_list, prec, prec->pid);
-				cpu_calc = (prec->ssec + prec->usec)/hertz;
+				cpu_calc = (double)(prec->ssec + prec->usec)/hertz;
 				/* tally their usage */
 				jobacct->max_rss =
 					MAX(jobacct->max_rss, prec->rss);


### PR DESCRIPTION
Change cpu_time measurements from uint32_t to double. This gives more accurate cpu utilization values when sampling at 1 second rate. Otherwise cpu utilization will be only 100 or 0. With this change it can be any value between 0 and 100.