### PR TITLE
Improved precission in CPU profiling from int to double

### DIFF
--- a/src/common/slurm_jobacct_gather.c
+++ b/src/common/slurm_jobacct_gather.c
@@ -872,10 +872,10 @@ extern void jobacctinfo_pack(jobacctinfo_t *jobacct,
 		pack64(jobacct->max_pages, buffer);
 		pack64(jobacct->tot_pages, buffer);
 		pack32((uint32_t)jobacct->min_cpu, buffer);
-		pack32((uint32_t)jobacct->tot_cpu, buffer);
 		pack32((uint32_t)jobacct->act_cpufreq, buffer);
 		pack64((uint64_t)jobacct->energy.consumed_energy, buffer);
 
+		packdouble((double)jobacct->tot_cpu, buffer);
 		packdouble((double)jobacct->max_disk_read, buffer);
 		packdouble((double)jobacct->tot_disk_read, buffer);
 		packdouble((double)jobacct->max_disk_write, buffer);
@@ -960,10 +960,10 @@ extern int jobacctinfo_unpack(jobacctinfo_t **jobacct,
 		safe_unpack64(&(*jobacct)->max_pages, buffer);
 		safe_unpack64(&(*jobacct)->tot_pages, buffer);
 		safe_unpack32(&(*jobacct)->min_cpu, buffer);
-		safe_unpack32(&(*jobacct)->tot_cpu, buffer);
 		safe_unpack32(&(*jobacct)->act_cpufreq, buffer);
 		safe_unpack64(&(*jobacct)->energy.consumed_energy, buffer);
 
+		safe_unpackdouble(&(*jobacct)->tot_cpu, buffer);
 		safe_unpackdouble(&(*jobacct)->max_disk_read, buffer);
 		safe_unpackdouble(&(*jobacct)->tot_disk_read, buffer);
 		safe_unpackdouble(&(*jobacct)->max_disk_write, buffer);
@@ -1008,7 +1008,7 @@ extern int jobacctinfo_unpack(jobacctinfo_t **jobacct,
 		safe_unpack64(&(*jobacct)->max_pages, buffer);
 		safe_unpack64(&(*jobacct)->tot_pages, buffer);
 		safe_unpack32(&(*jobacct)->min_cpu, buffer);
-		safe_unpack32(&(*jobacct)->tot_cpu, buffer);
+		safe_unpackdouble(&(*jobacct)->tot_cpu, buffer);
 		safe_unpack32(&(*jobacct)->act_cpufreq, buffer);
 		safe_unpack32(&uint32_tmp, buffer);
 		(*jobacct)->energy.consumed_energy = (uint64_t) uint32_tmp;

--- a/src/common/slurm_jobacct_gather.h
+++ b/src/common/slurm_jobacct_gather.h
@@ -115,11 +115,11 @@ struct jobacctinfo {
 			     (used to figure out ave later) */
 	uint32_t min_cpu; /* min cpu time */
 	jobacct_id_t min_cpu_id; /* contains which task it was on */
-	uint32_t tot_cpu; /* total cpu time(used to figure out ave later) */
+	double tot_cpu; /* total cpu time(used to figure out ave later) */
 	uint32_t act_cpufreq; /* actual cpu frequency */
 	acct_gather_energy_t energy;
-	uint32_t last_total_cputime;
-	uint32_t this_sampled_cputime;
+	double last_total_cputime;
+	double this_sampled_cputime;
 	uint32_t current_weighted_freq;
 	uint32_t current_weighted_power;
 	double max_disk_read; /* max disk read data */

--- a/src/plugins/jobacct_gather/common/common_jag.c
+++ b/src/plugins/jobacct_gather/common/common_jag.c
@@ -658,7 +658,7 @@ static void _record_profile(struct jobacctinfo *jobacct)
 
 	acct_gather_profile_dataset_t dataset[] = {
 		{ "CPUFrequency", PROFILE_FIELD_UINT64 },
-		{ "CPUTime", PROFILE_FIELD_UINT64 },
+		{ "CPUTime", PROFILE_FIELD_DOUBLE },
 		{ "CPUUtilization", PROFILE_FIELD_DOUBLE },
 		{ "RSS", PROFILE_FIELD_UINT64 },
 		{ "VMSize", PROFILE_FIELD_UINT64 },
@@ -703,19 +703,19 @@ static void _record_profile(struct jobacctinfo *jobacct)
 
 	/* delta from last snapshot */
 	if (!jobacct->last_time) {
-		data[FIELD_CPUTIME].u64 = 0;
+		data[FIELD_CPUTIME].d = 0.0;
 		data[FIELD_CPUUTIL].d = 0.0;
 		data[FIELD_READ].d = 0.0;
 		data[FIELD_WRITE].d = 0.0;
 	} else {
-		data[FIELD_CPUTIME].u64 =
+		data[FIELD_CPUTIME].d =
 			jobacct->tot_cpu - jobacct->last_total_cputime;
 		et = (jobacct->cur_time - jobacct->last_time);
 		if (!et)
 			data[FIELD_CPUUTIL].d = 0.0;
 		else
 			data[FIELD_CPUUTIL].d =
-				(100.0 * (double)data[FIELD_CPUTIME].u64) /
+				(100.0 * (double)data[FIELD_CPUTIME].d) /
 				((double) et);
 
 		data[FIELD_READ].d = jobacct->tot_disk_read -
@@ -838,8 +838,8 @@ extern void jag_common_poll_data(
 
 	itr = list_iterator_create(task_list);
 	while ((jobacct = list_next(itr))) {
-		uint32_t cpu_calc;
-		uint32_t last_total_cputime;
+		double cpu_calc;
+		double last_total_cputime;
 		if (!(prec = list_find_first(prec_list, _find_prec, jobacct)))
 			continue;
 
@@ -854,7 +854,7 @@ extern void jag_common_poll_data(
 
 		last_total_cputime = jobacct->tot_cpu;
 
-		cpu_calc = (prec->ssec + prec->usec)/hertz;
+		cpu_calc = (double)(prec->ssec + prec->usec)/hertz;
 		/* tally their usage */
 		jobacct->max_rss =
 			MAX(jobacct->max_rss, prec->rss);
@@ -885,7 +885,7 @@ extern void jag_common_poll_data(
 		jobacct->user_cpu_sec = prec->usec/hertz;
 		jobacct->sys_cpu_sec = prec->ssec/hertz;
 		debug2("%s: %d mem size %"PRIu64" %"PRIu64" "
-		       "time %u(%u+%u)", __func__,
+		       "time %f(%u+%u)", __func__,
 		       jobacct->pid, jobacct->max_rss,
 		       jobacct->max_vsize, jobacct->tot_cpu,
 		       jobacct->user_cpu_sec,
@@ -900,7 +900,7 @@ extern void jag_common_poll_data(
 			_update_weighted_freq(jobacct, sbuf);
 		debug("%s: Task average frequency = %u "
 		       "pid %d mem size %"PRIu64" %"PRIu64" "
-		       "time %u(%u+%u)", __func__,
+		       "time %f(%u+%u)", __func__,
 		       jobacct->act_cpufreq,
 		       jobacct->pid, jobacct->max_rss,
 		       jobacct->max_vsize, jobacct->tot_cpu,


### PR DESCRIPTION
This should close bug 1748. 
Can this be included in the 15.08 release? This needs a change in the jobacctinfo pack and unpack functions because of the type change.