### PR TITLE
fix non-system munge builds - ref bug 1842

### DIFF
--- a/src/plugins/jobcomp/script/jobcomp_script.c
+++ b/src/plugins/jobcomp/script/jobcomp_script.c
@@ -174,6 +174,8 @@ static const char * _jobcomp_script_strerror (int errnum)
  */
 struct jobcomp_info {
 	uint32_t jobid;
+	uint32_t array_job_id;
+	uint32_t array_task_id;
 	uint32_t uid;
 	uint32_t gid;
 	uint32_t limit;
@@ -208,6 +210,8 @@ static struct jobcomp_info * _jobcomp_info_create (struct job_record *job)
 	j->uid = job->user_id;
 	j->gid = job->group_id;
 	j->name = xstrdup (job->name);
+	j->array_job_id = job->array_job_id;
+	j->array_task_id = job->array_task_id;
 
 	if (IS_JOB_RESIZING(job)) {
 		state = JOB_RESIZING;
@@ -379,6 +383,8 @@ static char ** _create_environment (struct jobcomp_info *job)
 	env[0] = NULL;
 
 	_env_append_fmt (&env, "JOBID", "%u",  job->jobid);
+	_env_append_fmt (&env, "ARRAYJOBID", "%u", job->array_job_id);
+	_env_append_fmt (&env, "ARRAYTASKID", "%u", job->array_task_id);
 	_env_append_fmt (&env, "UID",   "%u",  job->uid);
 	_env_append_fmt (&env, "GID",   "%u",  job->gid);
 	_env_append_fmt (&env, "START", "%ld", (long)job->start);

--- a/src/plugins/mpi/mvapich/Makefile.am
+++ b/src/plugins/mpi/mvapich/Makefile.am
@@ -4,7 +4,7 @@ AUTOMAKE_OPTIONS = foreign
 
 PLUGIN_FLAGS = -module -avoid-version --export-dynamic
 
-AM_CPPFLAGS = -I$(top_srcdir) -I$(top_srcdir)/src/common
+AM_CPPFLAGS = -I$(top_srcdir) -I$(top_srcdir)/src/common $(MUNGE_CPPFLAGS)
 
 if WITH_MUNGE
 MVAPICH = mpi_mvapich.la
@@ -15,4 +15,4 @@ pkglib_LTLIBRARIES = $(MVAPICH)
 mpi_mvapich_la_SOURCES = mpi_mvapich.c mvapich.c mvapich.h \
 	$(top_srcdir)/src/common/mpi.h
 
-mpi_mvapich_la_LDFLAGS = $(SO_LDFLAGS) $(PLUGIN_FLAGS) $(MUNGE_LIBS)
+mpi_mvapich_la_LDFLAGS = $(SO_LDFLAGS) $(PLUGIN_FLAGS) $(MUNGE_LDFLAGS) $(MUNGE_LIBS)


### PR DESCRIPTION
add munge CPPFLAGS and LDFLAGS to mvapich plugin build;  was preventing installation with custom munge location;  tested on regular linux cluster