### PR TITLE
Filter out PreemptMode 'gang' flag for per-partition/qos cases

### DIFF
--- a/src/plugins/preempt/job_prio/preempt_job_prio.c
+++ b/src/plugins/preempt/job_prio/preempt_job_prio.c
@@ -855,15 +855,18 @@ extern List find_preemptable_jobs(struct job_record *job_ptr)
 extern uint16_t job_preempt_mode(struct job_record *job_ptr)
 {
 	uint16_t mode;
+	slurmdb_qos_rec_t *qos_ptr =(slurmdb_qos_rec_t *)job_ptr->qos_ptr;
 
-	if (job_ptr->qos_ptr &&
-	   ((slurmdb_qos_rec_t *)job_ptr->qos_ptr)->preempt_mode) {
-		mode = ((slurmdb_qos_rec_t *)job_ptr->qos_ptr)->preempt_mode;
+	if (qos_ptr && qos_ptr->preempt_mode) {
+		mode = qos_ptr->preempt_mode;
 		if (slurm_get_debug_flags() & DEBUG_FLAG_PRIO) {
 			info("%s: in job_preempt_mode return = %s",
 			     plugin_type, preempt_mode_string(mode));
 		}
-		return mode;
+		if (mode & PREEMPT_MODE_GANG)
+			verbose("QOS '%s' preempt mode 'gang' has no sense. "
+				"Filtered out.\n", qos_ptr->name);
+		return (mode & (~PREEMPT_MODE_GANG));
 	}
 
 	mode = slurm_get_preempt_mode() & (~PREEMPT_MODE_GANG);

--- a/src/plugins/preempt/partition_prio/preempt_partition_prio.c
+++ b/src/plugins/preempt/partition_prio/preempt_partition_prio.c
@@ -179,9 +179,13 @@ static int _sort_by_prio (void *x, void *y)
 /**************************************************************************/
 extern uint16_t job_preempt_mode(struct job_record *job_ptr)
 {
-	if (job_ptr->part_ptr &&
-	    (job_ptr->part_ptr->preempt_mode != (uint16_t) NO_VAL))
-		return job_ptr->part_ptr->preempt_mode;
+	struct part_record *part_ptr = job_ptr->part_ptr;
+	if (part_ptr && (part_ptr->preempt_mode != (uint16_t) NO_VAL)) {
+		if (part_ptr->preempt_mode & PREEMPT_MODE_GANG)
+			verbose("Partition '%s' preempt mode 'gang' has no "
+				"sense. Filtered out.\n", part_ptr->name);
+		return (part_ptr->preempt_mode & (~PREEMPT_MODE_GANG));
+	}
 
 	return (slurm_get_preempt_mode() & (~PREEMPT_MODE_GANG));
 }

--- a/src/plugins/preempt/qos/preempt_qos.c
+++ b/src/plugins/preempt/qos/preempt_qos.c
@@ -199,9 +199,13 @@ static int _sort_by_prio (void *x, void *y)
 /**************************************************************************/
 extern uint16_t job_preempt_mode(struct job_record *job_ptr)
 {
-	if (job_ptr->qos_ptr &&
-	    ((slurmdb_qos_rec_t *)job_ptr->qos_ptr)->preempt_mode)
-		return ((slurmdb_qos_rec_t *)job_ptr->qos_ptr)->preempt_mode;
+	slurmdb_qos_rec_t *qos_ptr =(slurmdb_qos_rec_t *)job_ptr->qos_ptr;
+	if (qos_ptr && qos_ptr->preempt_mode) {
+		if (qos_ptr->preempt_mode & PREEMPT_MODE_GANG)
+			verbose("QOS '%s' preempt mode 'gang' has no sense. "
+				"Filtered out.\n", qos_ptr->name);
+		return (qos_ptr->preempt_mode & (~PREEMPT_MODE_GANG));
+	}
 
 	return (slurm_get_preempt_mode() & (~PREEMPT_MODE_GANG));
 }


### PR DESCRIPTION
Filter out PreemptMode 'gang' flag for per-partition/qos cases as it doesn't make any sense for them.

Current behavior that per-partition/qos e.g. 'PreemptMode=suspend,gang' without any notice produces effect  equal to 'PreemptMode=cancel'. And that might be very confusing to user.

I've already submitted BZ ticket about this: http://bugs.schedmd.com/show_bug.cgi?id=1895