### PR TITLE
Add query capability for spank_job_env and spank_job_env_size fields from job_submit_lua

### DIFF
--- a/src/plugins/job_submit/lua/job_submit_lua.c
+++ b/src/plugins/job_submit/lua/job_submit_lua.c
@@ -347,6 +347,23 @@ static int _job_rec_field(const struct job_record *job_ptr,
 		lua_pushnumber (L, job_ptr->wait4switch);
 	} else if (!strcmp(name, "wckey")) {
 		lua_pushstring (L, job_ptr->wckey);
+    } else if (!strcmp(name, "spank_job_env")) {
+        if (job_ptr->spank_job_env_size == 0 || job_ptr->spank_job_env == NULL) {
+            lua_pushnil (L);
+        } else {
+            int idx = 0;
+            int lidx = 1;
+            lua_newtable(L);
+            for (idx = 0; idx < job_ptr->spank_job_env_size; idx++) {
+                if (job_ptr->spank_job_env[idx] != NULL) {
+                    lua_pushnumber (L, lidx++);
+                    lua_pushstring (L, job_ptr->spank_job_env[idx]);
+                    lua_settable (L, -3);
+                }
+            }
+        }
+    } else if (!strcmp(name, "spank_job_env_size")) {
+        lua_pushnumber (L, job_ptr->spank_job_env_size);
 	} else {
 		lua_pushnil (L);
 	}

--- a/src/plugins/job_submit/lua/job_submit_lua.c
+++ b/src/plugins/job_submit/lua/job_submit_lua.c
@@ -771,6 +771,23 @@ static int _get_job_req_field(const struct job_descriptor *job_desc,
 		lua_pushstring (L, job_desc->work_dir);
 	} else if (!strcmp(name, "wckey")) {
 		lua_pushstring (L, job_desc->wckey);
+    } else if (!strcmp(name, "spank_job_env")) {
+        if (job_desc->spank_job_env_size == 0 || job_desc->spank_job_env == NULL) {
+            lua_pushnil (L);
+        } else {
+            int idx = 0;
+            int lidx = 1;
+            lua_newtable(L);
+            for (idx = 0; idx < job_desc->spank_job_env_size; idx++) {
+                if (job_desc->spank_job_env[idx] != NULL) {
+                    lua_pushnumber (L, lidx++);
+                    lua_pushstring (L, job_desc->spank_job_env[idx]);
+                    lua_settable (L, -3);
+                }
+            }
+        }
+    } else if (!strcmp(name, "spank_job_env_size")) {
+        lua_pushnumber (L, job_desc->spank_job_env_size);
 	} else {
 		lua_pushnil (L);
 	}


### PR DESCRIPTION
Want to add logic to job_submit.lua to potentially reject jobs that engage conflicting spank plugins or use spank plugins in such a way that violates site policy.