### PR TITLE
problem exporting checkpotint dir

### DIFF
--- a/src/common/slurm_protocol_api.c
+++ b/src/common/slurm_protocol_api.c
@@ -1011,7 +1011,6 @@ extern char *slurm_get_checkpoint_type(void)
 	return checkpoint_type;
 }
 
-
 /* slurm_get_checkpoint_dir
  * returns the job_ckpt_dir from slurmctld_conf object
  * RET char *    - checkpoint dir, MUST be xfreed by caller
@@ -4660,4 +4659,3 @@ uint16_t slurm_get_prolog_timeout(void)
 
 	return timeout;
 }
-

--- a/src/common/slurm_protocol_api.c
+++ b/src/common/slurm_protocol_api.c
@@ -1011,6 +1011,25 @@ extern char *slurm_get_checkpoint_type(void)
 	return checkpoint_type;
 }
 
+
+/* slurm_get_checkpoint_dir
+ * returns the job_ckpt_dir from slurmctld_conf object
+ * RET char *    - checkpoint dir, MUST be xfreed by caller
+ */
+extern char *slurm_get_checkpoint_dir(void)
+{
+	char *checkpoint_dir = NULL;
+	slurm_ctl_conf_t *conf;
+
+	if (slurmdbd_conf) {
+	} else {
+		conf = slurm_conf_lock();
+		checkpoint_dir = xstrdup(conf->job_ckpt_dir);
+		slurm_conf_unlock();
+	}
+	return checkpoint_dir;
+}
+
 /* slurm_get_cluster_name
  * returns the cluster name from slurmctld_conf object
  * RET char *    - cluster name,  MUST be xfreed by caller

--- a/src/common/slurm_protocol_api.h
+++ b/src/common/slurm_protocol_api.h
@@ -424,6 +424,13 @@ extern char *slurm_get_bb_type(void);
  */
 extern char *slurm_get_checkpoint_type(void);
 
+ /* slurm_get_checkpoint_dir
+  * returns the checkpoint_dir from slurmctld_conf object
+  * RET char *    - checkpoint dir, MUST be xfreed by caller
+  */
+extern char *slurm_get_checkpoint_dir(void);
+
+
 /* slurm_get_cluster_name
  * returns the cluster name from slurmctld_conf object
  * RET char *    - cluster name,  MUST be xfreed by caller

--- a/src/common/slurm_protocol_api.h
+++ b/src/common/slurm_protocol_api.h
@@ -430,7 +430,6 @@ extern char *slurm_get_checkpoint_type(void);
   */
 extern char *slurm_get_checkpoint_dir(void);
 
-
 /* slurm_get_cluster_name
  * returns the cluster name from slurmctld_conf object
  * RET char *    - cluster name,  MUST be xfreed by caller

--- a/src/sbatch/opt.c
+++ b/src/sbatch/opt.c
@@ -408,7 +408,7 @@ static void _opt_default()
 
 	opt.ckpt_interval = 0;
 	opt.ckpt_interval_str = NULL;
-	opt.ckpt_dir = xstrdup(opt.cwd);
+	opt.ckpt_dir = slurm_get_checkpoint_dir();
 
 	opt.nice = 0;
 	opt.priority = 0;

--- a/src/srun/libsrun/opt.c
+++ b/src/srun/libsrun/opt.c
@@ -427,7 +427,7 @@ static void _opt_default(void)
 	opt.time_min_str = NULL;
 	opt.ckpt_interval = 0;
 	opt.ckpt_interval_str = NULL;
-	opt.ckpt_dir = NULL;
+	opt.ckpt_dir = slurm_get_checkpoint_dir();
 	opt.restart_dir = NULL;
 	opt.partition = NULL;
 	opt.max_threads = MAX_THREADS;


### PR DESCRIPTION
hi,

I've noticed that parameter JobCheckpointDir has a (from my point of view) inconsistent behavior. 

- in sbatch executions, it is exported as CWD
- in srun it is also exported as CWD, 
- except when it is manually set with "--checkpoint-dir=dir". If so, that value is exported.
- value defined in slurm.conf is, as far as I know, never read.

I have created this small patch to correct that behaviour. Now it is exported with the value configured on slurm.conf. If nothing is set, returned value is the defined on common/read_config.h, 

#define DEFAULT_JOB_CKPT_DIR        "/var/slurm/checkpoint".

Best regards,

Manuel
