### PR TITLE
Fix autoconf files to enable "--without-PACKAGE" feature.

### DIFF
--- a/auxdir/x_ac_blcr.m4
+++ b/auxdir/x_ac_blcr.m4
@@ -24,7 +24,7 @@ AC_DEFUN([X_AC_BLCR], [
   AC_ARG_WITH(
     [blcr],
     AS_HELP_STRING(--with-blcr=PATH,Specify path to BLCR installation),
-    [_x_ac_blcr_dirs="$withval $_x_ac_blcr_dirs"])
+    [_x_ac_blcr_dirs="$withval"])
 
   AC_CACHE_CHECK(
     [for blcr installation],

--- a/auxdir/x_ac_freeipmi.m4
+++ b/auxdir/x_ac_freeipmi.m4
@@ -17,7 +17,7 @@ AC_DEFUN([X_AC_FREEIPMI],
   AC_ARG_WITH(
     [freeipmi],
     AS_HELP_STRING(--with-freeipmi=PATH,Specify path to freeipmi installation),
-    [_x_ac_freeipmi_dirs="$withval $_x_ac_freeipmi_dirs"])
+    [_x_ac_freeipmi_dirs="$withval"])
 
   AC_CACHE_CHECK(
     [for freeipmi installation],

--- a/auxdir/x_ac_hwloc.m4
+++ b/auxdir/x_ac_hwloc.m4
@@ -18,7 +18,7 @@ AC_DEFUN([X_AC_HWLOC],
   AC_ARG_WITH(
     [hwloc],
     AS_HELP_STRING(--with-hwloc=PATH,Specify path to hwloc installation),
-    [_x_ac_hwloc_dirs="$withval $_x_ac_hwloc_dirs"])
+    [_x_ac_hwloc_dirs="$withval"])
 
   AC_CACHE_CHECK(
     [for hwloc installation],

--- a/auxdir/x_ac_json.m4
+++ b/auxdir/x_ac_json.m4
@@ -21,7 +21,7 @@ AC_DEFUN([X_AC_JSON], [
   AC_ARG_WITH(
     [json],
     AS_HELP_STRING(--with-json=PATH,Specify path to json-c installation),
-    [x_ac_json_dirs="$withval $x_ac_json_dirs"])
+    [x_ac_json_dirs="$withval"])
 
   AC_CACHE_CHECK(
     [for json installation],

--- a/auxdir/x_ac_munge.m4
+++ b/auxdir/x_ac_munge.m4
@@ -24,7 +24,7 @@ AC_DEFUN([X_AC_MUNGE], [
   AC_ARG_WITH(
     [munge],
     AS_HELP_STRING(--with-munge=PATH,Specify path to munge installation),
-    [_x_ac_munge_dirs="$withval $_x_ac_munge_dirs"])
+    [_x_ac_munge_dirs="$withval"])
 
   AC_CACHE_CHECK(
     [for munge installation],

--- a/auxdir/x_ac_netloc.m4
+++ b/auxdir/x_ac_netloc.m4
@@ -18,7 +18,7 @@ AC_DEFUN([X_AC_NETLOC],
   AC_ARG_WITH(
     [netloc],
     AS_HELP_STRING(--with-netloc=PATH,Specify path to netloc installation),
-    [_x_ac_netloc_dirs="$withval $_x_ac_netloc_dirs"])
+    [_x_ac_netloc_dirs="$withval"])
 
   AC_CACHE_CHECK(
     [for netloc installation],

--- a/auxdir/x_ac_ofed.m4
+++ b/auxdir/x_ac_ofed.m4
@@ -17,7 +17,7 @@ AC_DEFUN([X_AC_OFED],
   AC_ARG_WITH(
     [ofed],
     AS_HELP_STRING(--with-ofed=PATH,Specify path to ofed installation),
-    [_x_ac_ofed_dirs="$withval $_x_ac_ofed_dirs"])
+    [_x_ac_ofed_dirs="$withval"])
 
   AC_CACHE_CHECK(
     [for ofed installation],

--- a/auxdir/x_ac_pmix.m4
+++ b/auxdir/x_ac_pmix.m4
@@ -17,7 +17,7 @@ AC_DEFUN([X_AC_PMIX],
   AC_ARG_WITH(
     [pmix],
     AS_HELP_STRING(--with-pmix=PATH,Specify path to pmix installation),
-    [_x_ac_pmix_dirs="$withval $_x_ac_pmix_dirs"])
+    [_x_ac_pmix_dirs="$withval"])
 
   AC_CACHE_CHECK(
     [for pmix installation],

--- a/auxdir/x_ac_rrdtool.m4
+++ b/auxdir/x_ac_rrdtool.m4
@@ -17,7 +17,7 @@ AC_DEFUN([X_AC_RRDTOOL],
   AC_ARG_WITH([rrdtool],
     AS_HELP_STRING(--with-rrdtool=PATH,
       Specify path to rrdtool-devel installation),
-    [_x_ac_rrdtool_dirs="$withval $_x_ac_rrdtool_dirs"],
+    [_x_ac_rrdtool_dirs="$withval"],
     [with_rrdtool=check])
 
 #  echo with rrdtool $with_rrdtool


### PR DESCRIPTION
Me and David had a problem when someone have pmix library installed in the standard path (`/usr/` or `/usr/local` and we still don't want to build with it. I decided to use `--without-pmix` option to explicitly deny configuration with pmix but realized that it doesn't work.
The problem was here:
```
_x_ac_pmix_dirs="/usr /usr/local"
...
_x_ac_pmix_dirs="$withval $_x_ac_pmix_dirs"
```
instead of using user path only we concatenate it with default directories. This forces `./configure` to **always** search in this directories making `--without-PACKAGE` feature unusable.
Once I fixed that for pmix I decided to check the rest of the files sinse I derived my `x_ac_pmix.m4` file from hwloc file and this part was the same there.

Here is the fix for all files where I found this problem.