### PR TITLE
Let sbatch process long lines.

### DIFF
--- a/src/api/job_info.c
+++ b/src/api/job_info.c
@@ -338,7 +338,7 @@ slurm_sprint_job_info ( job_info_t * job_ptr, int one_liner )
 	char time_str[32], *group_name, *spec_name, *user_name;
 	char tmp1[128], tmp2[128], tmp3[128], tmp4[128], tmp5[128], tmp6[128];
 	char *tmp6_ptr;
-	char tmp_line[1024];
+	char tmp_line[1024 * 128];
 	char *ionodes = NULL;
 	uint16_t exit_status = 0, term_sig = 0;
 	job_resources_t *job_resrcs = job_ptr->job_resrcs;

--- a/src/sbatch/opt.c
+++ b/src/sbatch/opt.c
@@ -954,7 +954,6 @@ static char *_next_line(const void *buf, int size, void **state)
 {
 	char *line;
 	char *current, *ptr;
-	int len;
 
 	if (*state == NULL) /* initial state */
 		*state = (void *)buf;
@@ -966,8 +965,7 @@ static char *_next_line(const void *buf, int size, void **state)
 	while ((*ptr != '\n') && (ptr < ((char *)buf+size)))
 		ptr++;
 
-	len = MIN((ptr-current), 1024);
-	line = xstrndup(current, len);
+	line = xstrndup(current, ptr-current);
 
 	/*
 	 *  Advance state past newline
@@ -992,11 +990,17 @@ static char *
 _get_argument(const char *file, int lineno, const char *line, int *skipped)
 {
 	const char *ptr;
-	char argument[BUFSIZ];
+	char *argument;
 	char q_char = '\0';
 	bool escape_flag = false;
 	bool quoted = false;
 	int i;
+
+    argument = malloc(strlen(line) + 1);
+    if (argument == NULL) {
+		fatal("%s: line %d: Could not allocate memory for argument in line [%s]",
+		      file, lineno, q_char, line);
+    }
 
 	ptr = line;
 	*skipped = 0;


### PR DESCRIPTION
Remove the 1024-character limit on lines in batch scripts, which was
causing long lines to be silently truncated. I noticed it when jobs were
getting created with fewer dependencies than specified.

Also increase the line length when showing job info.