### PR TITLE
Fix use of uninitialized variable in Perl API's slurm_job_step_get_pids

### DIFF
--- a/contribs/perlapi/libslurm/perl/Slurm.xs
+++ b/contribs/perlapi/libslurm/perl/Slurm.xs
@@ -1564,7 +1564,7 @@ HV *
 slurm_job_step_get_pids(slurm_t self, uint32_t job_id, uint32_t step_id, char *nodelist=NULL)
 	PREINIT:
 		int rc;
-		job_step_pids_response_msg_t *resp_msg;
+		job_step_pids_response_msg_t *resp_msg = NULL;
 	CODE:
 		if (self); /* this is needed to avoid a warning about
 			      unused variables.  But if we take slurm_t self


### PR DESCRIPTION
That fix is required to prevent segmentation fault:

Program terminated with signal 11, Segmentation fault.
#0  0x00002aaab22c855a in slurm_job_step_get_pids (job_id=1843, step_id=0, node_list=0x876230 "dcalph052", resp=0x7fffffffdcd8)
    at job_step_info.c:548
548	        resp_out->job_id = req.job_id = job_id;


That  happens because src/api/job_step_info.c:slurm_job_step_get_pids()  does next

...
        if (!*resp) {
                resp_out = xmalloc(sizeof(job_step_pids_response_msg_t));
                *resp = resp_out;
                created = 1;
        } else
                resp_out = *resp;
...
