### PR TITLE
Changing 'access denied' message of pam_slurm to be more clear

### DIFF
--- a/contribs/pam/pam_slurm.c
+++ b/contribs/pam/pam_slurm.c
@@ -382,7 +382,7 @@ _send_denial_msg(pam_handle_t *pamh, struct _options *opts,
 	/*  Construct msg to send to app.
 	 */
 	n = snprintf(str, sizeof(str),
-		     "%sAccess denied: user %s (uid=%d) has no active jobs.%s",
+		     "%sAccess denied: User %s (uid=%d) has no active jobs on this node.%s",
 		     opts->msg_prefix, user, uid, opts->msg_suffix);
 	if ((n < 0) || (n >= sizeof(str)))
 		_log_msg(LOG_ERR, "exceeded buffer for pam_conv message");


### PR DESCRIPTION
The previous message to the user was ambiguous.  This change clarifies the reason a user's access to a node is denied.