### PR TITLE
Append srun to salloc while using qsub -I.

### DIFF
--- a/contribs/torque/qsub.pl
+++ b/contribs/torque/qsub.pl
@@ -296,6 +296,7 @@ $command .= " --mail-user=$mail_user_list" if $mail_user_list;
 $command .= " -J $job_name" if $job_name;
 $command .= " --nice=$priority" if $priority;
 $command .= " -p $destination" if $destination;
+$command .= " $srun --pty \$SHELL" if $interactive;
 $command .= " $script" if $script;
 
 # print "$command\n";


### PR DESCRIPTION
Otherwise you will stay on "head" node and execute scripts there.