### PR TITLE
possible bug in smap Makefile

### DIFF
--- a/src/smap/Makefile.am
+++ b/src/smap/Makefile.am
@@ -6,7 +6,7 @@
 
 AUTOMAKE_OPTIONS = foreign
 
-LIBS=$(NCURSES)
+LIBS+= $(NCURSES)
 AM_CPPFLAGS = -I$(top_srcdir) $(BG_INCLUDES)
 
 if BUILD_SMAP


### PR DESCRIPTION
LIBS can have a previous value, as depicted in ./configure --help

"Some influential environment variables:
(...)
 LIBS        libraries to pass to the linker, e.g. -l<library>
"
Original assignation to LIBS overwrites this value. With this patch, the user defined flags and NCURSES ones are both employed by the linker.