### PR TITLE
Seff updates

### DIFF
--- a/contribs/seff/seff
+++ b/contribs/seff/seff
@@ -66,13 +66,34 @@ my $user = $job->{'user'};
 my $group = getgrgid($job->{'gid'});
 my $state = $slurm->job_state_string($job->{'state'});
 $clustername = $job->{'cluster'};
-my $ncpus = $job->{'alloc_cpus'};
-# Check for missing number of cpus.
-if ($ncpus == 0) { $ncpus = 1; }
-my $reqmem = $job->{'req_mem'};
-my $nnodes = $job->{'alloc_nodes'};
+
+my $ncpus = 1;
+if (exists $job->{'alloc_cpus'}) {
+    $ncpus = $job->{'alloc_cpus'};
+} else {
+    if (exists $job->{'tres_alloc_str'}) {
+	$ncpus = Slurmdb::find_tres_count_in_string($job->{'tres_alloc_str'}, TRES_CPU);
+    }
+}
+# Check for missing number of cpus
+if (($ncpus == INFINITE64) || ($ncpus == 0)) {
+	$ncpus = 1;
+}
+
+my $nnodes = 1;
+if (exists $job->{'alloc_nodes'}) {
+    $nnodes = $job->{'alloc_nodes'};
+} else {
+    if (exists $job->{'tres_alloc_str'}) {
+        $nnodes = Slurmdb::find_tres_count_in_string($job->{'tres_alloc_str'}, TRES_NODE);
+    }
+}
 # Check for missing number of nodes.
-if ($nnodes == 0) { $nnodes = 1; }
+if (($nnodes == INFINITE64) || ($nnodes == 0)) {
+	$nnodes = 1;
+}
+
+my $reqmem = $job->{'req_mem'};
 my $pernode;
 if ($reqmem & MEM_PER_CPU) {
     $reqmem = ($reqmem & ~MEM_PER_CPU) * 1024 * $ncpus;

--- a/slurm.spec
+++ b/slurm.spec
@@ -388,7 +388,7 @@ Includes the Slurm proctrack/lua and job_submit/lua plugin
 %package seff
 Summary: Mail tool that includes job statistics in user notification email
 Group: Development/System
-Requires: slurm
+Requires: slurm-perlapi
 %description seff
 Mail program used directly by the Slurm daemons. On completion of a job,
 wait for it's accounting information to be available and include that


### PR DESCRIPTION
This version of seff fixes these kinds of warnings:

Use of uninitialized value $ncpus in numeric eq (==) at /usr/bin/seff line 71, <DATA> line 620.

both in 15.08 and 16.05.0-pre2.  It is also the version we've been using in production for a while now.

Also seff uses perlapi.