### PR TITLE
This fixes the pmi2 plugin to support singleton mode with PMIX_Ring

### DIFF
--- a/contribs/pmi2/pmi2_api.c
+++ b/contribs/pmi2/pmi2_api.c
@@ -656,6 +656,15 @@ int PMIX_Ring(const char value[], int *rank, int *ranks, char left[], char right
 
     PMI2U_printf("[BEGIN PMI2_Ring]");
 
+    /* for singleton mode, set rank and ranks, copy input to output buffers */
+    if (PMI2_initialized == SINGLETON_INIT_BUT_NO_PM) {
+        *rank  = 0;
+        *ranks = 1;
+        MPIU_Strncpy(left,  value, maxvalue);
+        MPIU_Strncpy(right, value, maxvalue);
+        goto fn_exit_singleton;
+    }
+
     /* send message: cmd=ring_in, count=1, left=value, right=value */
     pmi2_errno = PMIi_WriteSimpleCommandStr(PMI2_fd, &cmd, RING_CMD,
 	RING_COUNT_KEY,   "1",
@@ -689,6 +698,7 @@ int PMIX_Ring(const char value[], int *rank, int *ranks, char left[], char right
 fn_exit:
     free(cmd.command);
     freepairs(cmd.pairs, cmd.nPairs);
+fn_exit_singleton:
     PMI2U_printf("[END PMI2_Ring]");
     return pmi2_errno;
 fn_fail:

--- a/contribs/pmi2/slurm/pmi2.h
+++ b/contribs/pmi2/slurm/pmi2.h
@@ -426,8 +426,8 @@ int PMI2_Job_Disconnect(const char jobid[]);
  
   Output Parameters:
   + rank  - returns caller's rank within ring
-  - ranks - returns number of procs within ring
-  - left  - buffer to receive value provided by (rank - 1) % ranks
+  . ranks - returns number of procs within ring
+  . left  - buffer to receive value provided by (rank - 1) % ranks
   - right - buffer to receive value provided by (rank + 1) % ranks
  
   Return values:
@@ -439,6 +439,14 @@ int PMI2_Job_Disconnect(const char jobid[]);
   process belongs.  All processes in the group must call this
   function, but a process may return before all processes have called
   the function.
+
+  The rank of a process within the ring may not be the same as its
+  rank returned by PMI2_Init.
+
+  For a process group consisting of a single process, this function
+  returns rank=0, ranks=1, and the input string in the value buffer
+  shall be copied to the left and right output buffers.  This same
+  behavior holds when the function is called in singleton mode.
 
 @*/
 #define HAVE_PMIX_RING 1 /* so one can conditionally compile with this funciton */

--- a/contribs/pmi2/testpmixring.c
+++ b/contribs/pmi2/testpmixring.c
@@ -24,14 +24,13 @@ main(int argc, char **argv)
     int spawned, size, rank, appnum;
     struct timeval tv, tv2;
     int ring_rank, ring_size;
-    char jobid[128];
     char val[128];
     char buf[128];
     char left[128];
     char right[128];
 
     {
-        int x = 1;
+        int x = 0;
 
         while (x) {
             fprintf(stderr, "attachme %d\n", getpid());
@@ -42,8 +41,6 @@ main(int argc, char **argv)
     gettimeofday(&tv, NULL);
 
     PMI2_Init(&spawned, &size, &rank, &appnum);
-
-    PMI2_Job_GetId(jobid, sizeof(buf));
 
     /* test PMIX_Ring */
     snprintf(val, sizeof(val), "pmi_rank=%d", rank);


### PR DESCRIPTION
Singleton mode is when someone runs an MPI application directly without using srun or mpirun.  Such jobs should start up as single-task MPI jobs.  It's possible to support this mode in PMIX_Ring, but it was overlooked in the original implementation.