### PR TITLE
hwloc: Fix for newer API versions

### DIFF
--- a/src/slurmd/common/xcpuinfo.c
+++ b/src/slurmd/common/xcpuinfo.c
@@ -212,7 +212,7 @@ get_cpuinfo(uint16_t *p_cpus, uint16_t *p_boards,
 	hwloc_topology_set_flags(topology, HWLOC_TOPOLOGY_FLAG_WHOLE_SYSTEM);
 
 	/* ignores cache, misc */
-#if HWLOC_API_VERSION <= 0x00010a00
+#if HWLOC_API_VERSION < 0x00020000
 	hwloc_topology_ignore_type (topology, HWLOC_OBJ_CACHE);
 	hwloc_topology_ignore_type (topology, HWLOC_OBJ_MISC);
 #else

--- a/src/slurmd/common/xcpuinfo.c
+++ b/src/slurmd/common/xcpuinfo.c
@@ -212,8 +212,23 @@ get_cpuinfo(uint16_t *p_cpus, uint16_t *p_boards,
 	hwloc_topology_set_flags(topology, HWLOC_TOPOLOGY_FLAG_WHOLE_SYSTEM);
 
 	/* ignores cache, misc */
+#if HWLOC_API_VERSION <= 0x00010a00
 	hwloc_topology_ignore_type (topology, HWLOC_OBJ_CACHE);
 	hwloc_topology_ignore_type (topology, HWLOC_OBJ_MISC);
+#else
+	hwloc_topology_set_type_filter(topology,HWLOC_OBJ_L1CACHE,
+				       HWLOC_TYPE_FILTER_KEEP_NONE);
+	hwloc_topology_set_type_filter(topology,HWLOC_OBJ_L2CACHE,
+				       HWLOC_TYPE_FILTER_KEEP_NONE);
+	hwloc_topology_set_type_filter(topology,HWLOC_OBJ_L3CACHE,
+				       HWLOC_TYPE_FILTER_KEEP_NONE);
+	hwloc_topology_set_type_filter(topology,HWLOC_OBJ_L4CACHE,
+				       HWLOC_TYPE_FILTER_KEEP_NONE);
+	hwloc_topology_set_type_filter(topology,HWLOC_OBJ_L5CACHE,
+				       HWLOC_TYPE_FILTER_KEEP_NONE);
+	hwloc_topology_set_type_filter(topology,HWLOC_OBJ_MISC
+				       ,HWLOC_TYPE_FILTER_KEEP_NONE);
+#endif
 
 	/* load topology */
 	debug2("hwloc_topology_load");


### PR DESCRIPTION
The hwloc API has been reworked. The function hwloc_topology_ignore_type () has been removed.
Also object HWLOC_OBJ_CACHE has been split in separate objects for the different levels of data and instruction caches. 
Replace hwloc_topology_ignore_type() by hwloc_topology_set_type_filter()
for API versions > 0x00010a00.

Signed-off-by: Egbert Eich <eich@suse.de>