### PR TITLE
QL - x_ac_databases.m4: Make mariadb_config an alternative to mysql_config

### DIFF
--- a/auxdir/x_ac_databases.m4
+++ b/auxdir/x_ac_databases.m4
@@ -22,9 +22,9 @@ AC_DEFUN([X_AC_DATABASES],
 		[_x_ac_mysql_bin="$withval"])
 
 	if test x$_x_ac_mysql_bin = xno; then
-    		AC_PATH_PROG(HAVEMYSQLCONFIG, mysql_config, no)
+		AC_PATH_PROGS(HAVEMYSQLCONFIG, [mysql_config mariadb_config], no)
 	else
-   		AC_PATH_PROG(HAVEMYSQLCONFIG, mysql_config, no, $_x_ac_mysql_bin)
+		AC_PATH_PROGS(HAVEMYSQLCONFIG, [mysql_config mariadb_config], no, $_x_ac_mysql_bin)
 	fi
 
 	if test x$HAVEMYSQLCONFIG = xno; then


### PR DESCRIPTION
On some distributions (notably Ubuntu xenial), the mariadb client
dev package doesn't include a compatibility link for mysql_config.
This patch makes configure look for mariadb_config as an alternative
and allows building the mysql plugins against mariadb client libs.