### PR TITLE
Include sysmacros.h in addition for major() & minor()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -124,7 +124,7 @@ AC_CHECK_HEADERS(mcheck.h values.h socket.h sys/socket.h  \
 AC_HEADER_SYS_WAIT
 AC_HEADER_TIME
 AC_HEADER_STDC
-
+AC_HEADER_MAJOR
 
 dnl Checks for structures.
 dnl

--- a/src/plugins/task/cgroup/task_cgroup_devices.c
+++ b/src/plugins/task/cgroup/task_cgroup_devices.c
@@ -34,12 +34,20 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA.
 \*****************************************************************************/
 
+#include "config.h"
+
 #define _GNU_SOURCE
 #include <glob.h>
 #include <limits.h>
 #include <sched.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#ifdef MAJOR_IN_MKDEV
+#  include <sys/mkdev.h>
+#endif
+#ifdef MAJOR_IN_SYSMACROS
+#  include <sys/sysmacros.h>
+#endif
 
 #include "slurm/slurm.h"
 #include "slurm/slurm_errno.h"


### PR DESCRIPTION
Starting from glibc-2.25 [1] the macros major and minor are only available
from sys/sysmacros.h. This patch uses an autoconf macro to detect the
location and includes the header accordingly.

1)
https://sourceware.org/ml/libc-alpha/2017-02/msg00079.html

Signed-off-by: Justin Lecher <jlec@gentoo.org>