### PR TITLE
Update KNL man page and web page to reflect experience with timeouts on Dell KNL nodes

### DIFF
--- a/doc/html/intel_knl.shtml
+++ b/doc/html/intel_knl.shtml
@@ -183,7 +183,10 @@ available and active feature fields and not modified by the NodeFeatures
 plugin.</p>
 
 <p>NOTE: For Dell KNL systems you must also include the<i>SystemType=Dell</i>
-option for successful operation.</p>
+option for successful operation and will likely need to increase the
+<i>SyscfgTimeout</i> to allow enough time for the command to successfully
+complete.  Experience at one site has shown that a 10 second timeout may
+be necessary, configured as <i>SyscfgTimeout=10000</i>.</p>
 
 <p>Slurm does not support the concept of multiple NUMA nodes
 within a single socket. If a KNL node is booted with multiple NUMA, then each

--- a/doc/man/man5/knl.conf.5
+++ b/doc/man/man5/knl.conf.5
@@ -171,7 +171,7 @@ This parameter is used only by the "knl_generic" plugin.
 \fBSyscfgTimeout\fR
 Timeout for \fBsyscfg\fR program in milliseconds.
 Default value is 1000 milliseconds.
-For Dell KNL systems, experience has shown that a higher value of 4000
+For Dell KNL systems, experience has shown that a higher value of 10000
 milliseconds is more appropriate.
 
 .TP


### PR DESCRIPTION
In bug 4793 I reported the issues we'd seen on Dell KNL nodes with the syscfg command taking far longer than Slurm expected.  We had set a default of 4 seconds which seemed to work but further testing revealed that sometimes it would take longer than that so we've increased the timeout to 10 seconds instead.

This pull request updates the suggested timeout mentioned in the manual page to that value and also updates the webpage for KNL support in Slurm to mention this as well.

Hope this is useful!

All the best,
Chris