### PR TITLE
sinfo/squeue: display parseable output with configurable delimiter

### DIFF
--- a/src/sinfo/print.c
+++ b/src/sinfo/print.c
@@ -94,11 +94,13 @@ int print_sinfo_list(List sinfo_list)
 	ListIterator i = list_iterator_create(sinfo_list);
 	sinfo_data_t *current;
 
-	if (params.node_field_flag)
-		_set_node_field_size(sinfo_list);
-	if (params.part_field_flag)
-		_set_part_field_size(sinfo_list);
-
+  if ( ! params.should_show_parseable ) {
+    if (params.node_field_flag)
+      _set_node_field_size(sinfo_list);
+    if (params.part_field_flag)
+      _set_part_field_size(sinfo_list);
+  }
+  
 	if (!params.no_header)
 		print_sinfo_entry(NULL);
 
@@ -114,11 +116,16 @@ int print_sinfo_entry(sinfo_data_t *sinfo_data)
 	ListIterator i = list_iterator_create(params.format_list);
 	sinfo_format_t *current;
 
-	while ((current = (sinfo_format_t *) list_next(i)) != NULL) {
+  current = (sinfo_format_t *) list_next(i);
+	while ( current != NULL ) {
 		if (current->function(sinfo_data, current->width,
 				      current->right_justify, current->suffix)
 		    != SLURM_SUCCESS)
 			return SLURM_ERROR;
+      
+    current = (sinfo_format_t *) list_next(i);
+    if ( (params.field_delimiter != NULL) && (current != NULL) )
+      fputs(params.field_delimiter, stdout);
 	}
 	list_iterator_destroy(i);
 

--- a/src/sinfo/sinfo.h
+++ b/src/sinfo/sinfo.h
@@ -188,6 +188,9 @@ struct sinfo_parameters {
 	int node_field_size;
 	int part_field_size;
 	int verbose;
+  
+  char* field_delimiter;
+  bool  should_show_parseable;
 
 	List  part_list;
 	List  format_list;

--- a/src/squeue/print.c
+++ b/src/squeue/print.c
@@ -402,7 +402,8 @@ static int _print_one_job_from_format(job_info_t * job, List list)
 	job_format_t *current;
 	int total_width = 0;
 
-	while ((current = (job_format_t *) list_next(iter)) != NULL) {
+  current = (job_format_t *) list_next(iter);
+	while (current != NULL) {
 		if (current->
 		    function(job, current->width, current->right_justify,
 			     current->suffix)
@@ -412,6 +413,9 @@ static int _print_one_job_from_format(job_info_t * job, List list)
 			total_width += (current->width + 1);
 		else
 			total_width += 10;
+    current = (job_format_t *) list_next(iter);
+    if ( (params.field_delimiter != NULL) && (current != NULL) )
+      fputs(params.field_delimiter, stdout);
 	}
 	list_iterator_destroy(iter);
 
@@ -2304,7 +2308,8 @@ static int _print_step_from_format(void *x, void *arg)
 	step_format_t *current;
 	int total_width = 0;
 
-	while ((current = (step_format_t *) list_next(i)) != NULL) {
+  current = (step_format_t *) list_next(i);
+	while (current != NULL) {
 		if (current->
 		    function(job_step, current->width,
 			     current->right_justify, current->suffix)
@@ -2314,6 +2319,9 @@ static int _print_step_from_format(void *x, void *arg)
 			total_width += current->width;
 		else
 			total_width += 10;
+    current = (step_format_t *) list_next(i);
+    if ( (params.field_delimiter != NULL) && (current != NULL) )
+      fputs(params.field_delimiter, stdout);
 	}
 	list_iterator_destroy(i);
 	printf("\n");

--- a/src/squeue/squeue.h
+++ b/src/squeue/squeue.h
@@ -102,6 +102,9 @@ struct squeue_parameters {
 	uint32_t user_id;	/* set if request for a single user ID */
 
 	uint32_t convert_flags;
+  
+  char* field_delimiter;
+  bool  should_show_parseable;
 
 	List  account_list;
 	List  format_list;


### PR DESCRIPTION
When requesting node/queue/job information using the sinfo and squeue utilities the fixed-width display of the information is undesirable for machine-parsed cases.  For long-format arguments, using zero-width runs the fields together:

```
$ sinfo --Format="nodeaddr:0,cpus:0"
NODE_ADDRCPUS
r00n0236
r00n0336
   :
```

Using short `--format` would work, but not every data point available via long-format tags are available in the short format.

This patch implements two new CLI flags to the sinfo and squeue utilities that can be used to produce machine-parseable output.

- added `-D/--delimiter=<DELIM>`
  - print a static string between each field displayed
- added `--parseable`
  - all fields zero width (print entire thing)
  - w/o explicit `-D/--delimiter`, a "|" delimiter is implied
- augmented long-format field name parsing to allow trailing suffixes
  - `<field-name>[:[.][<width>][<suffix>]]`
  - Example:  --Format="nodeaddr:0|,features:0:,cpus:0"
```
$ sinfo --Format="nodeaddr:0|,features:0:,cpus:0"
NODE_ADDR|AVAIL_FEATURES:CPUS
r00n02|E5-2695,E5-2695v4:36
r00n03|E5-2695,E5-2695v4:36
   :
```