### PR TITLE
Avoid jobs being killed when squeue command fails to obtain job_list

### DIFF
--- a/etc/slurm.epilog.clean
+++ b/etc/slurm.epilog.clean
@@ -23,6 +23,14 @@ if [ $SLURM_UID -lt 100 ] ; then
 fi
 
 job_list=`${SLURM_BIN}squeue --noheader --format=%A --user=$SLURM_UID --node=localhost`
+squeue_exit_status=$?
+#
+# Don't try to kill if squeue command fails
+#
+if [ $squeue_exit_status -ne 0 ]; then
+        exit 0
+fi
+
 for job_id in $job_list
 do
 	if [ $job_id -ne $SLURM_JOB_ID ] ; then


### PR DESCRIPTION
When the slurm.epilog.clean script fails to obtain the `job_list` by some communication problem between SLURM compute and scheduler, other SLURM jobs from the user can be killed unintentionally. 

Adding the `if` statement to check the exit status of the `squeue` command allows to avoid that problem(as a workaround).