### PR TITLE
make errno strings const

### DIFF
--- a/slurm/slurm_errno.h
+++ b/slurm/slurm_errno.h
@@ -290,7 +290,7 @@ enum {
 };
 
 /* look up an errno value */
-char * slurm_strerror(int errnum);
+const char * slurm_strerror(int errnum);
 
 /* set an errno value */
 void slurm_seterrno(int errnum);
@@ -299,7 +299,7 @@ void slurm_seterrno(int errnum);
 int slurm_get_errno(void);
 
 /* print message: error string for current errno value */
-void slurm_perror(char *msg);
+void slurm_perror(const char *msg);
 
 #ifdef __cplusplus
 }

--- a/src/common/slurm_errno.c
+++ b/src/common/slurm_errno.c
@@ -543,7 +543,7 @@ static char *_lookup_slurm_api_errtab(int errnum)
  * Return string associated with error (Slurm or system).
  * Always returns a valid string (because strerror always does).
  */
-char *slurm_strerror(int errnum)
+const char *slurm_strerror(int errnum)
 {
 	char *res = _lookup_slurm_api_errtab(errnum);
 	if (res)
@@ -577,7 +577,7 @@ void slurm_seterrno(int errnum)
 /*
  * Print "message: error description" on stderr for current errno value.
  */
-void slurm_perror(char *msg)
+void slurm_perror(const char *msg)
 {
 	fprintf(stderr, "%s: %s\n", msg, slurm_strerror(errno));
 }


### PR DESCRIPTION
This makes it easier to pass string literals to slurm_perror(3).  For
example, a recent GCC emits the following when a string literal is passed
in C++:

   ISO C++ forbids converting a string constant to 'char*'