### PR TITLE
pam_slurm_adopt: send_user_msg: don't copy undefined data into message

### DIFF
--- a/contribs/pam_slurm_adopt/helper.c
+++ b/contribs/pam_slurm_adopt/helper.c
@@ -128,7 +128,7 @@ send_user_msg(pam_handle_t *pamh, const char *mesg)
 
 	/*  Construct msg to send to app.
 	 */
-	memcpy(str, mesg, sizeof(str));
+	strncpy(str, mesg, sizeof(str));
 	msg[0].msg_style = PAM_ERROR_MSG;
 	msg[0].msg = str;
 	pmsg[0] = &msg[0];


### PR DESCRIPTION
Originating from a security audit of pam_slurm_adopt for inclusion in SUSE Linux distributions.

Using memcpy, an amount of undefined data from the stack will be copied
into the target buffer. While pam_conv probably doesn't evalute the
extra data it still unclean to do that. It could lead up to an
information leak somewhen.