### PR TITLE
pam_slurm_adopt: avoid running outside of the sshd PAM service context

### DIFF
--- a/contribs/pam_slurm_adopt/README
+++ b/contribs/pam_slurm_adopt/README
@@ -97,6 +97,15 @@ This module has the following options (* = default):
         0* = If the step the job is adopted into has X11 enabled, set
              the DISPLAY variable in the processes environment accordingly.
 
+    service - The pam service name for which this module should run. By default
+              it only runs for sshd for which it was designed for. A
+              different service name can be specified like "login" or "*" to
+              allow the module to in any service context. For local pam logins
+              this module could cause unexpected behaviour or even security
+              issues. Therefore if the service name does not match then this
+              module will not perform the adoption logic and returns
+              PAM_IGNORE immediately.
+
 SLURM.CONF CONFIGURATION
   PrologFlags=contain must be set in slurm.conf. This sets up the "extern" step
   into which ssh-launched processes will be adopted.


### PR DESCRIPTION
Originating from a security audit of pam_slurm_adopt for inclusion in
SUSE Linux distributions.

This pam module is tailored towards running in the context of remote ssh
logins. When running in a different context like a local sudo call then
the module could be influenced by e.g. passing environment variables
like SLURM_CONF.

By limiting the module to only perform its actions when running in the
sshd context by default this situation can be avoided. An additional pam
module argument service=<service> allows an Administrator to control
this behaviour, if different behaviour is explicitly desired.