### PR TITLE
Added new yaml parameter (remote_nfs_target) to pass a data disk target

### DIFF
--- a/contribs/gcp/slurm-cluster.yaml
+++ b/contribs/gcp/slurm-cluster.yaml
@@ -34,9 +34,8 @@ resources:
     compute_machine_type    : n1-standard-2
     login_machine_type      : n1-standard-1
 
-    slurm_version           : 17.11.13
+    slurm_version           : <slurm version e.g. 17.11.13>
     default_account         : default
-    default_users           : garzoglio
-    munge_key               : 3706df00dbae9668b06c412f416d7acb082f5a7cb262599e86c896cbab043b6c6a96300d76e4d46c2b051f427e2c74f1f2e34394e156f6862683730ed52f2281
-    remote_nfs_target       : 10.221.183.170:/pfizerdata
+    default_users           : <comma separated list of users>
+    munge_key               : <.e.g date +%s | sha512sum | cut -d' ' -f1 >
 #  [END cluster_yaml]

--- a/contribs/gcp/slurm-cluster.yaml
+++ b/contribs/gcp/slurm-cluster.yaml
@@ -26,16 +26,17 @@ resources:
     cluster_name            : google1
     static_node_count       : 2
     max_node_count          : 10
-    zone                    : us-east1-b
-    region                  : us-east1
-    cidr                    : 10.10.0.0/16
+    zone                    : us-central1-a
+    region                  : us-central1
+    cidr                    : 10.11.0.0/16
 
     controller_machine_type : n1-standard-2
     compute_machine_type    : n1-standard-2
     login_machine_type      : n1-standard-1
 
-    slurm_version           : <slurm version e.g. 17.11.5>
+    slurm_version           : 17.11.13
     default_account         : default
-    default_users           : <comma separated list of users>
-    munge_key               : <.e.g date +%s | sha512sum | cut -d' ' -f1 >
+    default_users           : garzoglio
+    munge_key               : 3706df00dbae9668b06c412f416d7acb082f5a7cb262599e86c896cbab043b6c6a96300d76e4d46c2b051f427e2c74f1f2e34394e156f6862683730ed52f2281
+    remote_nfs_target       : 10.221.183.170:/pfizerdata
 #  [END cluster_yaml]

--- a/contribs/gcp/slurm.jinja
+++ b/contribs/gcp/slurm.jinja
@@ -16,20 +16,20 @@
 # limitations under the License.
 
 resources:
-- name: pfizer-demo
+- name: slurm-network
   type: compute.v1.network
   properties:
     autoCreateSubnetworks: false
-- name: pfizer-demo-subnet
+- name: slurm-subnet
   type: compute.v1.subnetwork
   properties:
-    network: $(ref.pfizer-demo.selfLink)
+    network: $(ref.slurm-network.selfLink)
     ipCidrRange: {{ properties["cidr"]}}
     region: {{ properties["region"] }}
 - name: ssh-firewall-rule
   type: compute.v1.firewall
   properties:
-    network: $(ref.pfizer-demo.selfLink)
+    network: $(ref.slurm-network.selfLink)
     sourceRanges: ["0.0.0.0/0"]
     allowed:
     - IPProtocol: TCP
@@ -38,7 +38,7 @@ resources:
 - name: all-internal-firewall-rule
   type: compute.v1.firewall
   properties:
-    network: $(ref.pfizer-demo.selfLink)
+    network: $(ref.slurm-network.selfLink)
     sourceRanges: [{{properties["cidr"]}}]
     allowed:
     - IPProtocol: TCP
@@ -51,7 +51,7 @@ resources:
 - name: no-ip-internet-route
   type: compute.v1.route
   properties:
-    network: $(ref.pfizer-demo.selfLink)
+    network: $(ref.slurm-network.selfLink)
     tags: ["compute"]
     destRange: 0.0.0.0/0
     nextHopInstance: https://www.googleapis.com/compute/v1/projects/{{ env["project"] }}/zones/{{ properties["zone"] }}/instances/controller
@@ -79,7 +79,7 @@ resources:
     canIpForward: true
 {% endif %}
     networkInterfaces:
-    - subnetwork: $(ref.pfizer-demo-subnet.selfLink)
+    - subnetwork: $(ref.slurm-subnet.selfLink)
       accessConfigs:
       - name: External NAT
         type: ONE_TO_ONE_NAT
@@ -127,7 +127,7 @@ resources:
         diskType: https://www.googleapis.com/compute/v1/projects/{{ env["project"] }}/zones/{{ properties["zone"] }}/diskTypes/{{ properties["login_disk_type"] }}
         diskSizeGb: {{ properties["login_disk_size_gb"] }}
     networkInterfaces:
-    - subnetwork: $(ref.pfizer-demo-subnet.selfLink)
+    - subnetwork: $(ref.slurm-subnet.selfLink)
       accessConfigs:
       - name: External NAT
         type: ONE_TO_ONE_NAT
@@ -161,7 +161,7 @@ resources:
         diskType: https://www.googleapis.com/compute/v1/projects/{{ env["project"] }}/zones/{{ properties["zone"] }}/diskTypes/{{ properties["compute_disk_type"] }}
         diskSizeGb: {{ properties["compute_disk_size_gb"] }}
     networkInterfaces:
-    - subnetwork: $(ref.pfizer-demo-subnet.selfLink)
+    - subnetwork: $(ref.slurm-subnet.selfLink)
 {% if properties['external_compute_ips'] %}
       accessConfigs:
       - name: External NAT

--- a/contribs/gcp/slurm.jinja
+++ b/contribs/gcp/slurm.jinja
@@ -16,20 +16,20 @@
 # limitations under the License.
 
 resources:
-- name: slurm-network
+- name: pfizer-demo
   type: compute.v1.network
   properties:
     autoCreateSubnetworks: false
-- name: slurm-subnet
+- name: pfizer-demo-subnet
   type: compute.v1.subnetwork
   properties:
-    network: $(ref.slurm-network.selfLink)
+    network: $(ref.pfizer-demo.selfLink)
     ipCidrRange: {{ properties["cidr"]}}
     region: {{ properties["region"] }}
 - name: ssh-firewall-rule
   type: compute.v1.firewall
   properties:
-    network: $(ref.slurm-network.selfLink)
+    network: $(ref.pfizer-demo.selfLink)
     sourceRanges: ["0.0.0.0/0"]
     allowed:
     - IPProtocol: TCP
@@ -38,7 +38,7 @@ resources:
 - name: all-internal-firewall-rule
   type: compute.v1.firewall
   properties:
-    network: $(ref.slurm-network.selfLink)
+    network: $(ref.pfizer-demo.selfLink)
     sourceRanges: [{{properties["cidr"]}}]
     allowed:
     - IPProtocol: TCP
@@ -51,7 +51,7 @@ resources:
 - name: no-ip-internet-route
   type: compute.v1.route
   properties:
-    network: $(ref.slurm-network.selfLink)
+    network: $(ref.pfizer-demo.selfLink)
     tags: ["compute"]
     destRange: 0.0.0.0/0
     nextHopInstance: https://www.googleapis.com/compute/v1/projects/{{ env["project"] }}/zones/{{ properties["zone"] }}/instances/controller
@@ -79,7 +79,7 @@ resources:
     canIpForward: true
 {% endif %}
     networkInterfaces:
-    - subnetwork: $(ref.slurm-subnet.selfLink)
+    - subnetwork: $(ref.pfizer-demo-subnet.selfLink)
       accessConfigs:
       - name: External NAT
         type: ONE_TO_ONE_NAT
@@ -100,10 +100,10 @@ resources:
       items:
         - key: startup-script
           value: |
-            {{ imports["scripts/startup-script.py"]|indent(12)|replace("@PROJECT@",env["project"])|replace("@ZONE@",properties["zone"])|replace("@INSTANCE_TYPE@","controller")|replace("@MUNGE_KEY@",properties["munge_key"])|replace("@SLURM_VERSION@",properties["slurm_version"])|replace("@STATIC_NODE_COUNT@",properties["static_node_count"])|replace("@MAX_NODE_COUNT@",properties["max_node_count"])|replace("@MACHINE_TYPE@",properties["compute_machine_type"])|replace("@DEF_SLURM_ACCT@",properties["default_account"])|replace("@DEF_SLURM_USERS@",properties["default_users"])|replace("@CLUSTER_NAME@",properties["cluster_name"])|replace("@EXTERNAL_COMPUTE_IPS@",properties["external_compute_ips"]) }}
+            {{ imports["scripts/startup-script.py"]|indent(12)|replace("@PROJECT@",env["project"])|replace("@ZONE@",properties["zone"])|replace("@INSTANCE_TYPE@","controller")|replace("@MUNGE_KEY@",properties["munge_key"])|replace("@SLURM_VERSION@",properties["slurm_version"])|replace("@STATIC_NODE_COUNT@",properties["static_node_count"])|replace("@MAX_NODE_COUNT@",properties["max_node_count"])|replace("@MACHINE_TYPE@",properties["compute_machine_type"])|replace("@DEF_SLURM_ACCT@",properties["default_account"])|replace("@DEF_SLURM_USERS@",properties["default_users"])|replace("@CLUSTER_NAME@",properties["cluster_name"])|replace("@EXTERNAL_COMPUTE_IPS@",properties["external_compute_ips"])|replace("@REMOTE_NFS_TARGET@",properties["remote_nfs_target"]) }}
         - key: startup-script-compute
           value: |
-            {{ imports["scripts/startup-script.py"]|indent(12)|replace("@PROJECT@",env["project"])|replace("@ZONE@",properties["zone"])|replace("@INSTANCE_TYPE@","compute")|replace("@MUNGE_KEY@",properties["munge_key"])|replace("@SLURM_VERSION@",properties["slurm_version"])|replace("@STATIC_NODE_COUNT@",properties["static_node_count"])|replace("@MAX_NODE_COUNT@",properties["max_node_count"])|replace("@MACHINE_TYPE@",properties["compute_machine_type"])|replace("@DEF_SLURM_ACCT@",properties["default_account"])|replace("@DEF_SLURM_USERS@",properties["default_users"])|replace("@CLUSTER_NAME@",properties["cluster_name"])|replace("@EXTERNAL_COMPUTE_IPS@",properties["external_compute_ips"]) }}
+            {{ imports["scripts/startup-script.py"]|indent(12)|replace("@PROJECT@",env["project"])|replace("@ZONE@",properties["zone"])|replace("@INSTANCE_TYPE@","compute")|replace("@MUNGE_KEY@",properties["munge_key"])|replace("@SLURM_VERSION@",properties["slurm_version"])|replace("@STATIC_NODE_COUNT@",properties["static_node_count"])|replace("@MAX_NODE_COUNT@",properties["max_node_count"])|replace("@MACHINE_TYPE@",properties["compute_machine_type"])|replace("@DEF_SLURM_ACCT@",properties["default_account"])|replace("@DEF_SLURM_USERS@",properties["default_users"])|replace("@CLUSTER_NAME@",properties["cluster_name"])|replace("@EXTERNAL_COMPUTE_IPS@",properties["external_compute_ips"])|replace("@REMOTE_NFS_TARGET@",properties["remote_nfs_target"]) }}
         - key: slurm_resume
           value: |
             {{ imports["scripts/resume.py"]|indent(12)|replace("@PROJECT@",env["project"])|replace("@ZONE@",properties["zone"])|replace("@REGION@",properties["region"])|replace("@MACHINE_TYPE@",properties["compute_machine_type"])|replace("@PREEMPTIBLE@",properties["preemptible_bursting"])|replace("@EXTERNAL_COMPUTE_IPS@",properties["external_compute_ips"])|replace("@DISK_SIZE_GB@",properties["compute_disk_size_gb"])|replace("@DISK_TYPE@",properties["compute_disk_type"])  }}
@@ -127,7 +127,7 @@ resources:
         diskType: https://www.googleapis.com/compute/v1/projects/{{ env["project"] }}/zones/{{ properties["zone"] }}/diskTypes/{{ properties["login_disk_type"] }}
         diskSizeGb: {{ properties["login_disk_size_gb"] }}
     networkInterfaces:
-    - subnetwork: $(ref.slurm-subnet.selfLink)
+    - subnetwork: $(ref.pfizer-demo-subnet.selfLink)
       accessConfigs:
       - name: External NAT
         type: ONE_TO_ONE_NAT
@@ -142,7 +142,7 @@ resources:
       items:
         - key: startup-script
           value: |
-            {{ imports["scripts/startup-script.py"]|indent(12)|replace("@PROJECT@",env["project"])|replace("@ZONE@",properties["zone"])|replace("@INSTANCE_TYPE@","login")|replace("@MUNGE_KEY@",properties["munge_key"])|replace("@SLURM_VERSION@",properties["slurm_version"])|replace("@STATIC_NODE_COUNT@",properties["static_node_count"])|replace("@MAX_NODE_COUNT@",properties["max_node_count"])|replace("@MACHINE_TYPE@",properties["compute_machine_type"])|replace("@DEF_SLURM_ACCT@",properties["default_account"])|replace("@DEF_SLURM_USERS@",properties["default_users"])|replace("@EXTERNAL_COMPUTE_IPS@",properties["external_compute_ips"]) }}
+            {{ imports["scripts/startup-script.py"]|indent(12)|replace("@PROJECT@",env["project"])|replace("@ZONE@",properties["zone"])|replace("@INSTANCE_TYPE@","login")|replace("@MUNGE_KEY@",properties["munge_key"])|replace("@SLURM_VERSION@",properties["slurm_version"])|replace("@STATIC_NODE_COUNT@",properties["static_node_count"])|replace("@MAX_NODE_COUNT@",properties["max_node_count"])|replace("@MACHINE_TYPE@",properties["compute_machine_type"])|replace("@DEF_SLURM_ACCT@",properties["default_account"])|replace("@DEF_SLURM_USERS@",properties["default_users"])|replace("@EXTERNAL_COMPUTE_IPS@",properties["external_compute_ips"])|replace("@REMOTE_NFS_TARGET@",properties["remote_nfs_target"]) }}
 
 
 {% for n in range(properties['static_node_count']) %}
@@ -161,7 +161,7 @@ resources:
         diskType: https://www.googleapis.com/compute/v1/projects/{{ env["project"] }}/zones/{{ properties["zone"] }}/diskTypes/{{ properties["compute_disk_type"] }}
         diskSizeGb: {{ properties["compute_disk_size_gb"] }}
     networkInterfaces:
-    - subnetwork: $(ref.slurm-subnet.selfLink)
+    - subnetwork: $(ref.pfizer-demo-subnet.selfLink)
 {% if properties['external_compute_ips'] %}
       accessConfigs:
       - name: External NAT
@@ -179,6 +179,6 @@ resources:
       items:
         - key: startup-script
           value: |
-            {{ imports["scripts/startup-script.py"]|indent(12)|replace("@PROJECT@",env["project"])|replace("@ZONE@",properties["zone"])|replace("@INSTANCE_TYPE@","compute")|replace("@MUNGE_KEY@",properties["munge_key"])|replace("@SLURM_VERSION@",properties["slurm_version"])|replace("@STATIC_NODE_COUNT@",properties["static_node_count"])|replace("@MAX_NODE_COUNT@",properties["max_node_count"])|replace("@MACHINE_TYPE@",properties["compute_machine_type"])|replace("@DEF_SLURM_ACCT@",properties["default_account"])|replace("@DEF_SLURM_USERS@",properties["default_users"])|replace("@EXTERNAL_COMPUTE_IPS@",properties["external_compute_ips"]) }}
+            {{ imports["scripts/startup-script.py"]|indent(12)|replace("@PROJECT@",env["project"])|replace("@ZONE@",properties["zone"])|replace("@INSTANCE_TYPE@","compute")|replace("@MUNGE_KEY@",properties["munge_key"])|replace("@SLURM_VERSION@",properties["slurm_version"])|replace("@STATIC_NODE_COUNT@",properties["static_node_count"])|replace("@MAX_NODE_COUNT@",properties["max_node_count"])|replace("@MACHINE_TYPE@",properties["compute_machine_type"])|replace("@DEF_SLURM_ACCT@",properties["default_account"])|replace("@DEF_SLURM_USERS@",properties["default_users"])|replace("@EXTERNAL_COMPUTE_IPS@",properties["external_compute_ips"])|replace("@REMOTE_NFS_TARGET@",properties["remote_nfs_target"]) }}
 {% endfor %}
 

--- a/contribs/gcp/slurm.jinja.schema
+++ b/contribs/gcp/slurm.jinja.schema
@@ -50,6 +50,7 @@ optional:
 - login_disk_size_gb
 - login_disk_type
 - preemptible_bursting
+- remote_nfs_target
 
 properties:
   cidr:
@@ -161,4 +162,8 @@ properties:
   zone:
     type        : string
     description : Zone to run the instances in based on Region.
+
+  remote_nfs_target:
+    type        : string
+    description : Remote NFS mount target for the login and compute nodes e.g. 10.221.183.170:/data
 


### PR DESCRIPTION
The new paramet triggers a mount via NFS in the login node and compute nodes under /mnt/data. 
This is useful, for example, to mount a cloud filestore target.