### PR TITLE
remove double occurrence of "the" in comments and docs

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -7251,7 +7251,7 @@ documents those changes that are of interest to users and administrators.
     run more than 256 jobs per node.
  -- sched/backfill: Improve accuracy of expected job start with respect to
     reservations.
- -- sinfo partition field size will be set the the length of the longest
+ -- sinfo partition field size will be set the length of the longest
     partition name by default.
  -- Make it so the parse_time will return a valid 0 if given epoch time and
     set errno == ESLURM_INVALID_TIME_VALUE on error instead.
@@ -7955,7 +7955,7 @@ documents those changes that are of interest to users and administrators.
     is set in slurm.conf. Patch from Don Albert, Bull.
  -- Added new sbatch option "--export-file" as needed for latest version of
     Moab. Patch from Phil Eckert, LLNL.
- -- Fix for sacct printing CPUTime(RAW) where the the is greater than a 32 bit
+ -- Fix for sacct printing CPUTime(RAW) where the is greater than a 32 bit
     number.
  -- Fix bug in --switch option with topology resulting in bad switch count use.
     Patch from Alejandro Lucero Palau (Barcelona Supercomputer Center).

--- a/doc/html/heterogeneous_jobs.shtml
+++ b/doc/html/heterogeneous_jobs.shtml
@@ -498,7 +498,7 @@ error: Attempt to run a job step with pack-group value of 2,
 <h2><a name="env_var">Environment Variables</a></h2>
 
 <p>Slurm environment variables will be set independently for each component of
-the job by appending "_PACK_GROUP_" and a sequence number the the usual name.
+the job by appending "_PACK_GROUP_" and a sequence number the usual name.
 In addition, the "SLURM_JOB_ID" environment variable will contain the job ID
 of the heterogeneous job leader and "SLURM_PACK_SIZE" will contain the number of
 components in the job. If using srun with a single specific pack group (for

--- a/doc/man/man1/squeue.1
+++ b/doc/man/man1/squeue.1
@@ -499,7 +499,7 @@ Prints whether the batch flag has been set.
 .TP
 \fBbatchhost\fR
 Executing (batch) host. For an allocated session, this is the host on which
-the session is executing (i.e. the node from which the the \fBsrun\fR or the
+the session is executing (i.e. the node from which the \fBsrun\fR or the
 \fBsalloc\fR command was executed). For a batch job, this is the node executing
 the batch script. In the case of a typical Linux cluster, this would be the
 compute node zero of the allocation. In the case of a Cray ALPS
@@ -715,7 +715,7 @@ reflect the current number of CPUs allocated.
 Number of nodes allocated to the job or the minimum number of nodes
 required by a pending job. The actual number of nodes allocated to a pending
 job may exceed this number if the job specified a node range count (e.g.
-minimum and maximum node counts) or the the job specifies a processor
+minimum and maximum node counts) or the job specifies a processor
 count instead of a node count and the cluster contains nodes with varying
 processor counts. As a job is completing this number will reflect the
 current number of nodes allocated.

--- a/doc/man/man5/knl.conf.5
+++ b/doc/man/man5/knl.conf.5
@@ -171,7 +171,7 @@ See also "Weight" in the node configuration specification of slurm.conf.
 Contains pairs of NUMA modes and the CpuBind mode to set a node to for that mode.
 Any compute node found with or set to the specified NUMA mode will have that
 node's CpuBind field set to the configured value.
-The NUMA node will be followed by an equal sign the the desired CpuBind mode for
+The NUMA node will be followed by an equal sign the desired CpuBind mode for
 that NUMA mode. Multiple NUMA mode and CpuBind modes should be in a semicolon
 separated list.
 By default changes to a node's NUMA mode will not effect that node's CpuBind

--- a/src/common/entity.h
+++ b/src/common/entity.h
@@ -139,7 +139,7 @@ void* entity_get_data_ref(const entity_t* entity, const char* key);
 
 /*
  * entity_set_data - copy the content of the input buffer up to the requested
- *       size into the the buffer associated to a particular key of an entity
+ *       size into the buffer associated to a particular key of an entity
  *       (note that the entity key value's buffer is allocated internally if
  *       necessary)
  *

--- a/src/common/forward.c
+++ b/src/common/forward.c
@@ -587,7 +587,7 @@ extern void forward_init(forward_t *forward, forward_t *from)
 /*
  * forward_msg        - logic to forward a message which has been received and
  *                      accumulate the return codes from processes getting the
- *                      the forwarded message
+ *                      forwarded message
  *
  * IN: forward_struct - forward_struct_t *   - holds information about message
  *                                             that needs to be forwarded to
@@ -627,7 +627,7 @@ extern int forward_msg(forward_struct_t *forward_struct, header_t *header)
 /*
  * start_msg_tree  - logic to begin the forward tree and
  *                   accumulate the return codes from processes getting the
- *                   the forwarded message
+ *                   forwarded message
  *
  * IN: hl          - hostlist_t   - list of every node to send message to
  * IN: msg         - slurm_msg_t  - message to send.

--- a/src/common/forward.h
+++ b/src/common/forward.h
@@ -54,7 +54,7 @@ extern void forward_init(forward_t *forward, forward_t *from);
 /*
  * forward_msg	      - logic to forward a message which has been received and
  *			accumulate the return codes from processes getting the
- *			the forwarded message
+ *			forwarded message
  *
  * IN: forward_struct - forward_struct_t *   - holds information about message
  *                                             that needs to be forwarded to
@@ -90,7 +90,7 @@ extern int forward_msg(forward_struct_t *forward_struct,
 /*
  * start_msg_tree  - logic to begin the forward tree and
  *                   accumulate the return codes from processes getting the
- *                   the forwarded message
+ *                   forwarded message
  *
  * IN: hl          - hostlist_t   - list of every node to send message to
  * IN: msg         - slurm_msg_t  - message to send.

--- a/src/common/xsignal.c
+++ b/src/common/xsignal.c
@@ -89,7 +89,7 @@ _sigmask(int how, sigset_t *set, sigset_t *oset)
 
 /*
  *  Fill in the sigset_t with the list of signals in the
- *   the (zero-terminated) array of signals `sigarray.'
+ *  (zero-terminated) array of signals `sigarray.'
  */
 int
 xsignal_sigset_create(int sigarray[], sigset_t *setp)

--- a/src/plugins/accounting_storage/mysql/as_mysql_fix_runaway_jobs.c
+++ b/src/plugins/accounting_storage/mysql/as_mysql_fix_runaway_jobs.c
@@ -194,7 +194,7 @@ extern int as_mysql_fix_runaway_jobs(mysql_conn_t *mysql_conn, uint32_t uid,
 		goto bail;
 	}
 
-	/* Set rollup to the the last day of the previous month of the first
+	/* Set rollup to the last day of the previous month of the first
 	 * runaway job */
 	rc = _first_job_roll_up(mysql_conn, first_job->start);
 	if (rc != SLURM_SUCCESS)

--- a/src/plugins/sched/backfill/backfill.c
+++ b/src/plugins/sched/backfill/backfill.c
@@ -3103,7 +3103,7 @@ static time_t _pack_start_find(struct job_record *job_ptr, time_t now)
 
 /*
  * Record the earliest that a pack job component can start. If it can be
- * started in multiple partitions, we only record the the earliest start time
+ * started in multiple partitions, we only record the earliest start time
  * for the job in any partition.
  */
 static void _pack_start_set(struct job_record *job_ptr, time_t latest_start,

--- a/src/plugins/select/cons_res/job_test.c
+++ b/src/plugins/select/cons_res/job_test.c
@@ -479,7 +479,7 @@ static uint16_t _allocate_sc(struct job_record *job_ptr, bitstr_t *core_map,
 		int task_cpus  = task_cores * threads_per_core;
 		/* find out how many tasks can fit on a node */
 		int tasks = avail_cpus / task_cpus;
-		/* how many cpus the the job would use on the node */
+		/* how many cpus the job would use on the node */
 		avail_cpus = tasks * task_cpus;
 		/* subtract out the extra cpus. */
 		avail_cpus -= (tasks * (task_cpus - cpus_per_task));

--- a/src/plugins/select/cons_tres/job_test.c
+++ b/src/plugins/select/cons_tres/job_test.c
@@ -5532,7 +5532,7 @@ static avail_res_t *_allocate_sc(struct job_record *job_ptr, bitstr_t *core_map,
 		int task_cpus  = task_cores * threads_per_core;
 		/* find out how many tasks can fit on a node */
 		int tasks = avail_cpus / task_cpus;
-		/* how many cpus the the job would use on the node */
+		/* how many cpus the job would use on the node */
 		avail_cpus = tasks * task_cpus;
 		/* subtract out the extra cpus. */
 		avail_cpus -= (tasks * (task_cpus - cpus_per_task));

--- a/src/slurmctld/controller.c
+++ b/src/slurmctld/controller.c
@@ -3356,7 +3356,7 @@ static void *_purge_files_thread(void *no_data)
 	 * There is a potential race condition if the job numbers have
 	 * wrapped between _purge_thread removing the state files and
 	 * get_next_job_id trying to re-assign it. This is mitigated
-	 * the the call to _dup_job_file_test() in job_mgr.c ensuring
+	 * the call to _dup_job_file_test() in job_mgr.c ensuring
 	 * there is no existing directory for an id before assigning it.
 	 */
 

--- a/src/slurmctld/fed_mgr.c
+++ b/src/slurmctld/fed_mgr.c
@@ -2977,11 +2977,11 @@ extern int fed_mgr_add_sibling_conn(slurm_persist_conn_t *persist_conn,
 	/* Preserve the persist_conn so that the cluster can get the remote
 	 * side's hostname and port to talk back to if it doesn't have it yet.
 	 * See _open_controller_conn().
-	 * Don't lock the the cluster's lock here because a (almost)deadlock
+	 * Don't lock the cluster's lock here because a (almost)deadlock
 	 * could occur if this cluster is opening a connection to the remote
 	 * cluster at the same time the remote cluster is connecting to this
 	 * cluster since the both sides will have the mutex locked in order to
-	 * send/recv. If it did happen the the connection will eventually
+	 * send/recv. If it did happen the connection will eventually
 	 * timeout and resolved itself. */
 	cluster->fed.recv = persist_conn;
 

--- a/src/slurmctld/job_mgr.c
+++ b/src/slurmctld/job_mgr.c
@@ -17405,7 +17405,7 @@ extern bool job_hold_requeue(struct job_record *job_ptr)
 	 */
 	if (state & JOB_SPECIAL_EXIT) {
 		/*
-		 * JOB_SPECIAL_EXIT means requeue the the job,
+		 * JOB_SPECIAL_EXIT means requeue the job,
 		 * put it on hold and display state as JOB_SPECIAL_EXIT.
 		 */
 		job_ptr->job_state |= JOB_SPECIAL_EXIT;

--- a/src/sreport/resv_reports.c
+++ b/src/sreport/resv_reports.c
@@ -549,7 +549,7 @@ extern int resv_utilization(int argc, char **argv)
 
 		tres_itr = list_iterator_create(resv_tres_list);
 		while ((resv_tres = list_next(tres_itr))) {
-			/* see if it is in the the requested tres list */
+			/* see if it is in the requested tres list */
 			if (!(req_tres = list_find_first(
 						req_tres_list,
 						slurmdb_find_tres_in_list,

--- a/src/srun/libsrun/launch.h
+++ b/src/srun/libsrun/launch.h
@@ -168,7 +168,7 @@ extern int launch_g_step_wait(srun_job_t *job, bool got_alloc,
 extern int launch_g_step_terminate(void);
 
 /*
- * launch_g_print_status() displays the the status of the job step.
+ * launch_g_print_status() displays the status of the job step.
  */
 extern void launch_g_print_status(void);
 

--- a/testsuite/expect/test10.10
+++ b/testsuite/expect/test10.10
@@ -46,7 +46,7 @@ if {[file exists $smap] == 0} {
 }
 
 #
-# Check the the --noheader option in smap
+# Check the --noheader option in smap
 # in curses format.
 #
 set timeout 10

--- a/testsuite/expect/test37.16
+++ b/testsuite/expect/test37.16
@@ -483,7 +483,7 @@ squeue "$fedc2" "8" $r2
 squeue "$fedc3" "7" $r3
 
 #check db
-# Test that job4 is marked REVOKED on the the removed cluster (fed1) and still
+# Test that job4 is marked REVOKED on the removed cluster (fed1) and still
 # pending on the other clusters.
 set matches 0
 


### PR DESCRIPTION
I noticed this in the doc and quickly fixed it everywhere.