### PR TITLE
fix build requirements for RPM build on RHEL 8

### DIFF
--- a/slurm.spec
+++ b/slurm.spec
@@ -61,9 +61,13 @@ Requires: munge
 
 %{?systemd_requires}
 BuildRequires: systemd
-BuildRequires: munge-devel munge-libs
-BuildRequires: python
 BuildRequires: readline-devel
+BuildRequires: munge-devel munge-libs
+%if 0%{el8}
+BuildRequires: python3
+%else
+BuildRequires: python
+%endif
 Obsoletes: slurm-lua slurm-munge slurm-plugins
 
 # fake systemd support when building rpms on other platforms


### PR DESCRIPTION
Change Python build requirement on RHEL 8 to python3. The generic "python" package is no longer available.

At the time of writing the munge-devel package is not in the RHEL 8 repositories. It's possible to build it yourself from the munge source RPM.