### PR TITLE
Fix for jobs stuck in configuring state in case of the frontend execution mode

### DIFF
--- a/src/slurmctld/job_mgr.c
+++ b/src/slurmctld/job_mgr.c
@@ -8677,6 +8677,17 @@ extern bool test_job_nodes_ready(job_record_t *job_ptr)
 		if ((select_g_job_ready(job_ptr) & READY_NODE_STATE) == 0)
 			return false;
 	} else if (job_ptr->batch_flag) {
+
+#ifdef HAVE_FRONT_END
+		/* Make sure frontend node is ready to start batch job */
+		front_end_record_t *front_end_ptr =
+			find_front_end_record(job_ptr->batch_host);
+		if (!front_end_ptr ||
+		    IS_NODE_POWER_SAVE(front_end_ptr) ||
+		    IS_NODE_POWER_UP(front_end_ptr)) {
+			return false;
+		}
+#else
 		/* Make sure first node is ready to start batch job */
 		node_record_t *node_ptr =
 			find_node_record(job_ptr->batch_host);
@@ -8685,6 +8696,7 @@ extern bool test_job_nodes_ready(job_record_t *job_ptr)
 		    IS_NODE_POWER_UP(node_ptr)) {
 			return false;
 		}
+#endif
 	}
 
 	return true;


### PR DESCRIPTION
Hello,

I had a problem running slurm in frontend mode (configured with --enable-front-end) for modeling purposes. Namely, all submitted jobs stay in configuring state:

```
             JOBID PARTITION     NAME     USER ST       TIME  NODES NODELIST(REASON) 
                20     debug sleep.jo nikolays CF       1:18      1 n1
```
It turns out that test_job_nodes_ready function from job_mgr.c checking the readiness of the first node for batch job execution. But in frontend mode, it is the task of the frontend node. So I added checking of frontend node instead. That fixed the problem.

Regards,
Nikolay

Used configuration:
[slurm.conf](https://github.com/SchedMD/slurm/files/4784569/slurm.conf.txt)
