### PR TITLE
macOS build compatibility for client tools

### DIFF
--- a/auxdir/slurm.m4
+++ b/auxdir/slurm.m4
@@ -96,7 +96,10 @@ AC_DEFUN([X_AC_LIBSLURM], [
     # You will notice " or ' each does something different when resolving
     # variables.  Some need to be resolved now ($libdir) and others
     # ($(top_builddir)) need to be resolved when dealing with the Makefile.am's
-    LIB_SLURM="-Wl,-rpath=$libdir/slurm"
+    case $host_os in
+      darwin*) LIB_SLURM="-Wl,-rpath,$libdir/slurm" ;;
+      *)       LIB_SLURM="-Wl,-rpath=$libdir/slurm" ;;
+    esac
     LIB_SLURM=$LIB_SLURM' -L$(top_builddir)/src/api/.libs -lslurmfull'
     AC_MSG_RESULT([shared]);
   fi

--- a/configure
+++ b/configure
@@ -835,6 +835,8 @@ CLANG_FALSE
 CLANG_TRUE
 SUCMD
 SLEEP_CMD
+DARWIN_FALSE
+DARWIN_TRUE
 WITH_GNU_LD_FALSE
 WITH_GNU_LD_TRUE
 WITH_CXX_FALSE
@@ -3913,7 +3915,7 @@ printf "%s\n" "#define SLURM_VERSION_STRING \"$SLURM_VERSION_STRING\"" >>confdef
 
 
 
-am__api_version='1.17'
+am__api_version='1.18'
 
 
   # Find a good install program.  We prefer a C program (faster),
@@ -4182,10 +4184,14 @@ am_lf='
 '
 case `pwd` in
   *[\\\"\#\$\&\'\`$am_lf]*)
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; }
     as_fn_error $? "unsafe absolute working directory name" "$LINENO" 5;;
 esac
 case $srcdir in
   *[\\\"\#\$\&\'\`$am_lf\ \	]*)
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; }
     as_fn_error $? "unsafe srcdir value: '$srcdir'" "$LINENO" 5;;
 esac
 
@@ -4645,9 +4651,133 @@ AMTAR='$${TAR-tar}'
 
 
 # We'll loop over all known methods to create a tar archive until one works.
-_am_tools='gnutar  pax cpio none'
+_am_tools='gnutar plaintar pax cpio none'
 
-am__tar='$${TAR-tar} chof - "$$tardir"' am__untar='$${TAR-tar} xf -'
+# The POSIX 1988 'ustar' format is defined with fixed-size fields.
+      # There is notably a 21 bits limit for the UID and the GID.  In fact,
+      # the 'pax' utility can hang on bigger UID/GID (see automake bug#8343
+      # and bug#13588).
+      am_max_uid=2097151 # 2^21 - 1
+      am_max_gid=$am_max_uid
+      # The $UID and $GID variables are not portable, so we need to resort
+      # to the POSIX-mandated id(1) utility.  Errors in the 'id' calls
+      # below are definitely unexpected, so allow the users to see them
+      # (that is, avoid stderr redirection).
+      am_uid=`id -u || echo unknown`
+      am_gid=`id -g || echo unknown`
+      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether UID '$am_uid' is supported by ustar format" >&5
+printf %s "checking whether UID '$am_uid' is supported by ustar format... " >&6; }
+      if test x$am_uid = xunknown; then
+        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: ancient id detected; assuming current UID is ok, but dist-ustar might not work" >&5
+printf "%s\n" "$as_me: WARNING: ancient id detected; assuming current UID is ok, but dist-ustar might not work" >&2;}
+      elif test $am_uid -le $am_max_uid; then
+        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+printf "%s\n" "yes" >&6; }
+      else
+        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; }
+        _am_tools=none
+      fi
+      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether GID '$am_gid' is supported by ustar format" >&5
+printf %s "checking whether GID '$am_gid' is supported by ustar format... " >&6; }
+      if test x$gm_gid = xunknown; then
+        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: ancient id detected; assuming current GID is ok, but dist-ustar might not work" >&5
+printf "%s\n" "$as_me: WARNING: ancient id detected; assuming current GID is ok, but dist-ustar might not work" >&2;}
+      elif test $am_gid -le $am_max_gid; then
+        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+printf "%s\n" "yes" >&6; }
+      else
+        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; }
+        _am_tools=none
+      fi
+
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking how to create a ustar tar archive" >&5
+printf %s "checking how to create a ustar tar archive... " >&6; }
+
+  # Go ahead even if we have the value already cached.  We do so because we
+  # need to set the values for the 'am__tar' and 'am__untar' variables.
+  _am_tools=${am_cv_prog_tar_ustar-$_am_tools}
+
+  for _am_tool in $_am_tools; do
+    case $_am_tool in
+    gnutar)
+      for _am_tar in tar gnutar gtar; do
+        { echo "$as_me:$LINENO: $_am_tar --version" >&5
+   ($_am_tar --version) >&5 2>&5
+   ac_status=$?
+   echo "$as_me:$LINENO: \$? = $ac_status" >&5
+   (exit $ac_status); } && break
+      done
+      am__tar="$_am_tar --format=ustar -chf - "'"$$tardir"'
+      am__tar_="$_am_tar --format=ustar -chf - "'"$tardir"'
+      am__untar="$_am_tar -xf -"
+      ;;
+    plaintar)
+      # Must skip GNU tar: if it does not support --format= it doesn't create
+      # ustar tarball either.
+      (tar --version) >/dev/null 2>&1 && continue
+      am__tar='tar chf - "$$tardir"'
+      am__tar_='tar chf - "$tardir"'
+      am__untar='tar xf -'
+      ;;
+    pax)
+      am__tar='pax -L -x ustar -w "$$tardir"'
+      am__tar_='pax -L -x ustar -w "$tardir"'
+      am__untar='pax -r'
+      ;;
+    cpio)
+      am__tar='find "$$tardir" -print | cpio -o -H ustar -L'
+      am__tar_='find "$tardir" -print | cpio -o -H ustar -L'
+      am__untar='cpio -i -H ustar -d'
+      ;;
+    none)
+      am__tar=false
+      am__tar_=false
+      am__untar=false
+      ;;
+    esac
+
+    # If the value was cached, stop now.  We just wanted to have am__tar
+    # and am__untar set.
+    test -n "${am_cv_prog_tar_ustar}" && break
+
+    # tar/untar a dummy directory, and stop if the command works.
+    rm -rf conftest.dir
+    mkdir conftest.dir
+    echo GrepMe > conftest.dir/file
+    { echo "$as_me:$LINENO: tardir=conftest.dir && eval $am__tar_ >conftest.tar" >&5
+   (tardir=conftest.dir && eval $am__tar_ >conftest.tar) >&5 2>&5
+   ac_status=$?
+   echo "$as_me:$LINENO: \$? = $ac_status" >&5
+   (exit $ac_status); }
+    rm -rf conftest.dir
+    if test -s conftest.tar; then
+      { echo "$as_me:$LINENO: $am__untar <conftest.tar" >&5
+   ($am__untar <conftest.tar) >&5 2>&5
+   ac_status=$?
+   echo "$as_me:$LINENO: \$? = $ac_status" >&5
+   (exit $ac_status); }
+      { echo "$as_me:$LINENO: cat conftest.dir/file" >&5
+   (cat conftest.dir/file) >&5 2>&5
+   ac_status=$?
+   echo "$as_me:$LINENO: \$? = $ac_status" >&5
+   (exit $ac_status); }
+      grep GrepMe conftest.dir/file >/dev/null 2>&1 && break
+    fi
+  done
+  rm -rf conftest.dir
+
+  if test ${am_cv_prog_tar_ustar+y}
+then :
+  printf %s "(cached) " >&6
+else case e in #(
+  e) am_cv_prog_tar_ustar=$_am_tool ;;
+esac
+fi
+
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $am_cv_prog_tar_ustar" >&5
+printf "%s\n" "$am_cv_prog_tar_ustar" >&6; }
 
 
 
@@ -5856,7 +5986,10 @@ _ACEOF
       break
     fi
   done
-  rm -f core conftest*
+  # aligned with autoconf, so not including core; see bug#72225.
+  rm -f -r a.out a.exe b.out conftest.$ac_ext conftest.$ac_objext \
+    conftest.dSYM conftest1.$ac_ext conftest1.$ac_objext conftest1.dSYM \
+    conftest2.$ac_ext conftest2.$ac_objext conftest2.dSYM
   unset am_i ;;
 esac
 fi
@@ -7045,7 +7178,10 @@ _ACEOF
       break
     fi
   done
-  rm -f core conftest*
+  # aligned with autoconf, so not including core; see bug#72225.
+  rm -f -r a.out a.exe b.out conftest.$ac_ext conftest.$ac_objext \
+    conftest.dSYM conftest1.$ac_ext conftest1.$ac_objext conftest1.dSYM \
+    conftest2.$ac_ext conftest2.$ac_objext conftest2.dSYM
   unset am_i ;;
 esac
 fi
@@ -20667,6 +20803,9 @@ printf "%s\n" "no" >&6; }
 		PKG_CONFIG=""
 	fi
 fi
+if test -z "$PKG_CONFIG"; then
+	as_fn_error $? "pkg-config not found" "$LINENO" 5
+fi
 
 
 
@@ -20831,6 +20970,14 @@ fi
 else
   WITH_GNU_LD_TRUE='#'
   WITH_GNU_LD_FALSE=
+fi
+
+ if case "$host_os" in darwin*) true ;; *) false ;; esac; then
+  DARWIN_TRUE=
+  DARWIN_FALSE='#'
+else
+  DARWIN_TRUE='#'
+  DARWIN_FALSE=
 fi
 
 
@@ -22218,7 +22365,10 @@ printf "%s\n" "static" >&6; };
     # You will notice " or ' each does something different when resolving
     # variables.  Some need to be resolved now ($libdir) and others
     # ($(top_builddir)) need to be resolved when dealing with the Makefile.am's
-    LIB_SLURM="-Wl,-rpath=$libdir/slurm"
+    case $host_os in
+      darwin*) LIB_SLURM="-Wl,-rpath,$libdir/slurm" ;;
+      *)       LIB_SLURM="-Wl,-rpath=$libdir/slurm" ;;
+    esac
     LIB_SLURM=$LIB_SLURM' -L$(top_builddir)/src/api/.libs -lslurmfull'
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: shared" >&5
 printf "%s\n" "shared" >&6; };
@@ -27909,6 +28059,9 @@ printf "%s\n" "no" >&6; }
 		PKG_CONFIG=""
 	fi
 fi
+if test -z "$PKG_CONFIG"; then
+	as_fn_error $? "pkg-config not found" "$LINENO" 5
+fi
 
   no_glib=""
 
@@ -28434,6 +28587,9 @@ printf "%s\n" "yes" >&6; }
 printf "%s\n" "no" >&6; }
 		PKG_CONFIG=""
 	fi
+fi
+if test -z "$PKG_CONFIG"; then
+	as_fn_error $? "pkg-config not found" "$LINENO" 5
 fi
 
   min_gtk_version=2.7.1
@@ -30641,6 +30797,10 @@ Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
 if test -z "${WITH_GNU_LD_TRUE}" && test -z "${WITH_GNU_LD_FALSE}"; then
   as_fn_error $? "conditional \"WITH_GNU_LD\" was never defined.
+Usually this means the macro was only invoked conditionally." "$LINENO" 5
+fi
+if test -z "${DARWIN_TRUE}" && test -z "${DARWIN_FALSE}"; then
+  as_fn_error $? "conditional \"DARWIN\" was never defined.
 Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
 if test -z "${CLANG_TRUE}" && test -z "${CLANG_FALSE}"; then

--- a/configure.ac
+++ b/configure.ac
@@ -76,6 +76,7 @@ AC_SUBST(AR_FLAGS, [cr])
 
 AM_CONDITIONAL(WITH_CXX, test -n "$ac_ct_CXX")
 AM_CONDITIONAL(WITH_GNU_LD, test "$with_gnu_ld" = "yes")
+AM_CONDITIONAL(DARWIN, [case "$host_os" in darwin*) true ;; *) false ;; esac])
 
 AC_PATH_PROG([SLEEP_CMD], [sleep], [/bin/sleep])
 AC_DEFINE_UNQUOTED([SLEEP_CMD], ["$SLEEP_CMD"], [Define path to sleep command])

--- a/make_ref.include
+++ b/make_ref.include
@@ -22,8 +22,18 @@ CLEANFILES = *.bino
 BIN_REF = $(REF:.txt=.bino)
 
 %.bino: %.txt
+if DARWIN
+	$(AM_V_GEN){ \
+	  sym=$$(echo "$(notdir $<)" | tr '/.-' '___'); \
+	  printf '.section __TEXT,__const\n.global __binary_%s_start\n__binary_%s_start:\n.incbin "%s"\n__binary_%s_end:\n.global __binary_%s_end\n' \
+	    "$$sym" "$$sym" "$(abs_srcdir)/$(notdir $<)" "$$sym" "$$sym" > "$*.s"; \
+	  $(CC) -c "$*.s" -o "$*.bino"; \
+	  rm -f "$*.s"; \
+	}
+else
 	$(AM_V_GEN)curr_dir=$(shell pwd); cd $(abs_srcdir); $(LD) -r $(LD_EMULATION) -o "$(abs_builddir)/$*.bino" -z noexecstack --format=binary "$(notdir $<)"; cd $$curr_dir
 	$(AM_V_at)@OBJCOPY@ --rename-section .data=.rodata,alloc,load,readonly,data,contents "$*.bino"
+endif
 
 lib_ref.lo: $(BIN_REF)
 	$(AM_V_at)echo "# $@ - a libtool object file" >"$@"

--- a/src/common/macros.h
+++ b/src/common/macros.h
@@ -50,6 +50,129 @@
 #include "src/common/log.h"	/* for error() */
 #include "src/common/strlcpy.h"
 
+#ifdef __APPLE__
+#include <fcntl.h>
+#include <stdio.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#ifndef SOCK_CLOEXEC
+#  define SOCK_CLOEXEC 0
+#endif
+
+static inline int accept4(int sockfd, struct sockaddr *addr,
+			   socklen_t *addrlen, int flags)
+{
+	int fd = accept(sockfd, addr, addrlen);
+	if (fd < 0)
+		return fd;
+	if (flags & O_CLOEXEC)
+		fcntl(fd, F_SETFD, FD_CLOEXEC);
+	if (flags & O_NONBLOCK)
+		fcntl(fd, F_SETFL, O_NONBLOCK);
+	return fd;
+}
+
+static inline int pipe2(int fds[2], int flags)
+{
+	if (pipe(fds) < 0)
+		return -1;
+	if (flags & O_CLOEXEC) {
+		fcntl(fds[0], F_SETFD, FD_CLOEXEC);
+		fcntl(fds[1], F_SETFD, FD_CLOEXEC);
+	}
+	if (flags & O_NONBLOCK) {
+		fcntl(fds[0], F_SETFL, O_NONBLOCK);
+		fcntl(fds[1], F_SETFL, O_NONBLOCK);
+	}
+	return 0;
+}
+
+static inline int fexecve(int fd, char *const argv[], char *const envp[])
+{
+	/* macOS does not have fexecve; fall back to /dev/fd path */
+	char path[32];
+	snprintf(path, sizeof(path), "/dev/fd/%d", fd);
+	execve(path, argv, envp);
+	return -1;
+}
+
+static inline int setresgid(gid_t rgid, gid_t egid, gid_t sgid)
+{
+	(void)sgid;
+	return setregid(rgid, egid);
+}
+
+static inline int setresuid(uid_t ruid, uid_t euid, uid_t suid)
+{
+	(void)suid;
+	return setreuid(ruid, euid);
+}
+
+/* POSIX real-time timer shims using setitimer(ITIMER_REAL) */
+#include <signal.h>
+#include <sys/time.h>
+#include <time.h>
+
+typedef int timer_t;
+
+#ifndef TIMER_ABSTIME
+#  define TIMER_ABSTIME 1
+#endif
+
+struct itimerspec {
+	struct timespec it_interval;
+	struct timespec it_value;
+};
+
+static inline int timer_create(int clockid, struct sigevent *sevp,
+				timer_t *timerid)
+{
+	(void)clockid;
+	(void)sevp;
+	*timerid = 0;
+	return 0;
+}
+
+static inline int timer_delete(timer_t timerid)
+{
+	(void)timerid;
+	struct itimerval val = {{0}};
+	return setitimer(ITIMER_REAL, &val, NULL);
+}
+
+static inline int timer_settime(timer_t timerid, int flags,
+				const struct itimerspec *new_value,
+				struct itimerspec *old_value)
+{
+	(void)timerid;
+	(void)old_value;
+	struct itimerval val = {{0}};
+
+	if (new_value->it_value.tv_sec == 0 &&
+	    new_value->it_value.tv_nsec == 0) {
+		return setitimer(ITIMER_REAL, &val, NULL);
+	}
+
+	if (flags & TIMER_ABSTIME) {
+		struct timespec now;
+		clock_gettime(CLOCK_REALTIME, &now);
+		long sec = new_value->it_value.tv_sec - now.tv_sec;
+		long nsec = new_value->it_value.tv_nsec - now.tv_nsec;
+		if (nsec < 0) { sec--; nsec += 1000000000L; }
+		if (sec < 0) sec = 0;
+		val.it_value.tv_sec = sec;
+		val.it_value.tv_usec = nsec / 1000;
+	} else {
+		val.it_value.tv_sec = new_value->it_value.tv_sec;
+		val.it_value.tv_usec = new_value->it_value.tv_nsec / 1000;
+	}
+	val.it_interval.tv_sec = new_value->it_interval.tv_sec;
+	val.it_interval.tv_usec = new_value->it_interval.tv_nsec / 1000;
+	return setitimer(ITIMER_REAL, &val, NULL);
+}
+#endif
+
 #define STACK_SIZE (8 * 1024 * 1024)
 
 #ifndef MAX

--- a/src/common/net.c
+++ b/src/common/net.c
@@ -46,6 +46,9 @@
 #include <netdb.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
+#ifndef SOL_TCP
+#  define SOL_TCP IPPROTO_TCP
+#endif
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
@@ -551,7 +554,9 @@ extern int net_get_peer(int fd, uid_t *cred_uid, gid_t *cred_gid,
 	struct xucred cred = {
 		.cr_uid = SLURM_AUTH_NOBODY,
 		.cr_groups = { SLURM_AUTH_NOBODY, },
+#ifdef __FreeBSD__
 		.cr_pid = 0,
+#endif
 	};
 	socklen_t len = sizeof(cred);
 
@@ -563,7 +568,11 @@ extern int net_get_peer(int fd, uid_t *cred_uid, gid_t *cred_gid,
 
 	*cred_uid = cred.cr_uid;
 	*cred_gid = cred.cr_groups[0];
+#ifdef __FreeBSD__
 	*cred_pid = cred.cr_pid;
+#else
+	*cred_pid = 0;
+#endif
 #endif
 
 	/* Sanity check returned creds */

--- a/src/common/slurm_resolv.c
+++ b/src/common/slurm_resolv.c
@@ -37,6 +37,9 @@
 
 #include <arpa/inet.h>
 #include <arpa/nameser.h>
+#ifdef __APPLE__
+#include <arpa/nameser_compat.h>
+#endif
 #include <netinet/in.h>
 #include <resolv.h>
 

--- a/src/common/xsched.c
+++ b/src/common/xsched.c
@@ -128,6 +128,9 @@ extern int slurm_setaffinity(pid_t pid, size_t size, const cpu_set_t *mask)
 #ifdef __FreeBSD__
 	rval = cpuset_setaffinity(CPU_LEVEL_WHICH, CPU_WHICH_PID, pid, size,
 				  mask);
+#elif defined(__APPLE__)
+	rval = -1;
+	errno = ENOTSUP;
 #else
 	rval = sched_setaffinity(pid, size, mask);
 #endif
@@ -156,6 +159,10 @@ extern int slurm_getaffinity(pid_t pid, size_t size, cpu_set_t *mask)
 #ifdef __FreeBSD__
 	rval = cpuset_getaffinity(CPU_LEVEL_WHICH, CPU_WHICH_PID, pid, size,
 				  mask);
+#elif defined(__APPLE__)
+	CPU_ZERO(mask);
+	rval = -1;
+	errno = ENOTSUP;
 #else
 	rval = sched_getaffinity(pid, size, mask);
 #endif
@@ -174,5 +181,13 @@ extern int task_cpuset_get_assigned_count(size_t size, cpu_set_t *mask)
 	if (!size || !mask)
 		return -1;
 
+#ifdef __APPLE__
+	int count = 0;
+	for (size_t i = 0; i < CPU_SETSIZE; i++)
+		if (CPU_ISSET(i, mask))
+			count++;
+	return count;
+#else
 	return CPU_COUNT_S(size, mask);
+#endif
 }

--- a/src/common/xsched.h
+++ b/src/common/xsched.h
@@ -42,6 +42,15 @@
 typedef cpuset_t cpu_set_t;
 #endif
 
+#ifdef __APPLE__
+typedef unsigned long cpu_set_t;
+#define CPU_SETSIZE (sizeof(cpu_set_t) * 8)
+#define CPU_ZERO(s)       (*(s) = 0)
+#define CPU_SET(n, s)     (*(s) |= (1UL << (n)))
+#define CPU_CLR(n, s)     (*(s) &= ~(1UL << (n)))
+#define CPU_ISSET(n, s)   (!!(*(s) & (1UL << (n))))
+#endif
+
 #ifdef __NetBSD__
 #define CPU_ZERO(c) cpuset_zero(*(c))
 #define CPU_ISSET(i, c) cpuset_isset((i), *(c))

--- a/src/plugins/cgroup/v1/cgroup_v1.h
+++ b/src/plugins/cgroup/v1/cgroup_v1.h
@@ -38,7 +38,9 @@
 
 #define _GNU_SOURCE		/* For POLLRDHUP, O_CLOEXEC on older glibc */
 #include <poll.h>
+#ifndef __APPLE__
 #include <sys/eventfd.h>
+#endif
 
 #include "slurm/slurm.h"
 #include "slurm/slurm_errno.h"

--- a/src/plugins/data_parser/v0.0.42/parsers.c
+++ b/src/plugins/data_parser/v0.0.42/parsers.c
@@ -36,6 +36,9 @@
 #include <limits.h>
 #include <math.h>
 #include <signal.h>
+#ifndef SIGRTMAX
+#  define SIGRTMAX 32
+#endif
 #include <stdint.h>
 #include <unistd.h>
 

--- a/src/plugins/data_parser/v0.0.43/parsers.c
+++ b/src/plugins/data_parser/v0.0.43/parsers.c
@@ -37,6 +37,9 @@
 #include <limits.h>
 #include <math.h>
 #include <signal.h>
+#ifndef SIGRTMAX
+#  define SIGRTMAX 32
+#endif
 #include <stdint.h>
 #include <unistd.h>
 

--- a/src/plugins/data_parser/v0.0.44/parsers.c
+++ b/src/plugins/data_parser/v0.0.44/parsers.c
@@ -37,6 +37,9 @@
 #include <limits.h>
 #include <math.h>
 #include <signal.h>
+#ifndef SIGRTMAX
+#  define SIGRTMAX 32
+#endif
 #include <stdint.h>
 #include <unistd.h>
 

--- a/src/plugins/data_parser/v0.0.45/parsers.c
+++ b/src/plugins/data_parser/v0.0.45/parsers.c
@@ -37,6 +37,9 @@
 #include <limits.h>
 #include <math.h>
 #include <signal.h>
+#ifndef SIGRTMAX
+#  define SIGRTMAX 32
+#endif
 #include <stdint.h>
 #include <unistd.h>
 

--- a/src/plugins/proctrack/cgroup/proctrack_cgroup.c
+++ b/src/plugins/proctrack/cgroup/proctrack_cgroup.c
@@ -42,9 +42,11 @@
 #include <poll.h>
 #include <signal.h>
 #include <stdlib.h>
+#ifndef __APPLE__
 #include <sys/eventfd.h>
 #include <sys/inotify.h>
 #include <sys/signalfd.h>
+#endif
 #include <sys/stat.h>
 #include <sys/types.h>
 

--- a/src/salloc/signals.c
+++ b/src/salloc/signals.c
@@ -34,7 +34,9 @@
 \*****************************************************************************/
 
 #include <signal.h>
+#ifndef __APPLE__
 #include <sys/eventfd.h>
+#endif
 
 #include "src/common/fd.h"
 #include "src/common/read_config.h"
@@ -46,6 +48,9 @@ pthread_mutex_t salloc_destroy_sig_lock = PTHREAD_MUTEX_INITIALIZER;
 int salloc_destroy_sig = 0;
 
 int salloc_sig_eventfd = -1;
+#ifdef __APPLE__
+static int salloc_sig_eventfd_write = -1;
+#endif
 
 #define SALLOC_SIGNALS \
 	X(SIGHUP, sighup) \
@@ -75,7 +80,11 @@ static void _on_signal(int signo)
 	 */
 	xassert(salloc_sig_eventfd != -1);
 
+#ifdef __APPLE__
+	safe_write(salloc_sig_eventfd_write, &val, sizeof(uint64_t));
+#else
 	safe_write(salloc_sig_eventfd, &val, sizeof(uint64_t));
+#endif
 	write_rc = SLURM_SUCCESS;
 rwfail:
 	if (write_rc != SLURM_SUCCESS)
@@ -124,10 +133,20 @@ SALLOC_SIGNALS
 
 extern void salloc_sig_init(void)
 {
+#ifdef __APPLE__
+	{
+		int pipe_fds[2];
+		if (pipe2(pipe_fds, O_CLOEXEC | O_NONBLOCK) == -1)
+			fatal("Could not create pipe for salloc signal handling: %m");
+		salloc_sig_eventfd = pipe_fds[0];
+		salloc_sig_eventfd_write = pipe_fds[1];
+	}
+#else
 	if ((salloc_sig_eventfd = eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK)) ==
 	    -1) {
 		fatal("Could not create eventfd for salloc signal handling: %m");
 	}
+#endif
 
 #define X(sig, str) conmgr_add_work_signal(sig, _on_##str, NULL);
 	SALLOC_SIGNALS

--- a/src/slurmd/slurmd/Makefile.am
+++ b/src/slurmd/slurmd/Makefile.am
@@ -15,7 +15,9 @@ depend_ldadd = $(HWLOC_LIBS) $(PAM_LIBS) $(UTIL_LIBS)
 depend_ldflags = $(HWLOC_LDFLAGS)
 
 # This is needed to actually link to the libs that it doesn't use.
+if !DARWIN
 depend_ldflags += -Wl,--no-as-needed
+endif
 
 AM_CPPFLAGS = -I$(top_srcdir) $(HWLOC_CPPFLAGS)
 

--- a/src/srun/signals.c
+++ b/src/srun/signals.c
@@ -33,7 +33,9 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA.
 \*****************************************************************************/
 
+#ifndef __APPLE__
 #include <sys/eventfd.h>
+#endif
 
 #include "src/common/fd.h"
 #include "src/common/read_config.h"
@@ -52,6 +54,9 @@ pthread_mutex_t srun_destroy_sig_lock = PTHREAD_MUTEX_INITIALIZER;
 int srun_destroy_sig = 0;
 
 int srun_sig_eventfd = -1;
+#ifdef __APPLE__
+static int srun_sig_eventfd_write = -1;
+#endif
 
 #define SRUN_SIGNALS \
 	X(SIGINT, sigint) \
@@ -172,7 +177,11 @@ static void _on_signal(int signo)
 	 */
 	xassert(srun_sig_eventfd != -1);
 
+#ifdef __APPLE__
+	safe_write(srun_sig_eventfd_write, &val, sizeof(uint64_t));
+#else
 	safe_write(srun_sig_eventfd, &val, sizeof(uint64_t));
+#endif
 	write_rc = SLURM_SUCCESS;
 rwfail:
 	if (write_rc != SLURM_SUCCESS)
@@ -210,9 +219,19 @@ SRUN_SIGNALS
 
 extern void srun_sig_init(void)
 {
+#ifdef __APPLE__
+	{
+		int pipe_fds[2];
+		if (pipe2(pipe_fds, O_CLOEXEC | O_NONBLOCK) == -1)
+			fatal("Could not create pipe for srun signal handling: %m");
+		srun_sig_eventfd = pipe_fds[0];
+		srun_sig_eventfd_write = pipe_fds[1];
+	}
+#else
 	if ((srun_sig_eventfd = eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK)) == -1) {
 		fatal("Could not create eventfd for srun signal handling: %m");
 	}
+#endif
 
 #define X(sig, str) conmgr_add_work_signal(sig, _on_##str, NULL);
 	SRUN_SIGNALS

--- a/src/srun/srun_job.c
+++ b/src/srun/srun_job.c
@@ -46,7 +46,9 @@
 #include <signal.h>
 #include <stdlib.h>
 #include <string.h>
+#ifndef __APPLE__
 #include <sys/eventfd.h>
+#endif
 #include <sys/resource.h>
 #include <sys/stat.h>
 #include <sys/types.h>


### PR DESCRIPTION
## Summary

I'm making an exploratory change here -- with the changes in the PR, I can successfully build slurm binaries. The idea here is that my main Macbook would be a submitter of jobs to the cluster. The changes are mostly around non-standard functions that only exist in Linux. I wonder if there'd be interest in moving to more standard APIs or actually accepting some of this compatibility code? If so, I'd be happy to look into changes one by one (so far: pipe2/accept4 seem like they could just work, also SOL_TCP -> IPPROTO_TCP would be no-op change with more compatibility too).

## Description

Enable building Slurm client tools (`squeue`, `sbatch`, `srun`, `sinfo`, `salloc`, `sacct`, `scancel`, `scontrol`) on macOS/Darwin without munge.

Tested on macOS 15 (Sequoia) / Apple Silicon (aarch64) with:
```
mkdir b && cd b
CPPFLAGS="-I/opt/homebrew/include" LDFLAGS="-L/opt/homebrew/lib" \
  ../configure --with-munge=no
make
```

## Changes

- **`src/common/xsched.h`**: add `cpu_set_t` typedef and `CPU_SET*` macros for macOS
- **`src/common/xsched.c`**: stub `sched_setaffinity`/`getaffinity` and `CPU_COUNT_S` for macOS
- **`src/common/macros.h`**: add macOS shims for `pipe2`, `accept4`, `fexecve`, `setresuid`/`setresgid`, `SOCK_CLOEXEC`, POSIX real-time timers (`timer_create`/`timer_settime`/`timer_delete`), and `struct itimerspec`
- **`src/common/net.c`**: define `SOL_TCP` as `IPPROTO_TCP`; guard `cr_pid` (FreeBSD-only field in `struct xucred`) for macOS
- **`src/common/slurm_resolv.c`**: include `arpa/nameser_compat.h` for `C_IN`/`T_SRV` on macOS
- **`src/plugins/data_parser/v0.0.{42-45}/parsers.c`**: define `SIGRTMAX` fallback (no RT signals on macOS)
- **`auxdir/slurm.m4`**: fix `-Wl,-rpath=` to `-Wl,-rpath,` for Apple ld64
- **`configure.ac`**: add `DARWIN` automake conditional
- **`make_ref.include`**: use clang `.incbin` assembler for binary embedding on macOS instead of GNU ld `--format=binary`
- **`src/slurmd/slurmd/Makefile.am`**: guard `-Wl,--no-as-needed` (GNU ld only)
- **`src/salloc/signals.c`**, **`src/srun/signals.c`**: replace `eventfd()` with pipe pair on macOS
- **`src/srun/srun_job.c`**, cgroup plugin headers: guard `<sys/eventfd.h>` include on macOS

## Test plan

- [ ] Build succeeds on macOS with `--with-munge=no`
- [ ] All client binaries link and load (`squeue --version`, etc.)
- [ ] Existing Linux CI passes unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)