### PR TITLE
fix: nodes_alloc stats overcount

### DIFF
--- a/src/slurmctld/statistics.c
+++ b/src/slurmctld/statistics.c
@@ -244,6 +244,7 @@ extern void reset_stats(int level)
 
 static void _free_job_stats(job_stats_t *j)
 {
+	FREE_NULL_BITMAP(j->node_bitmap);
 	xfree(j->user_name);
 	xfree(j->partition);
 	xfree(j->account);
@@ -551,10 +552,17 @@ static int _fill_jobs_statistics(void *x, void *arg)
 		new->memory_alloc =
 			(j->tres_alloc_cnt ? j->tres_alloc_cnt[TRES_ARRAY_MEM] :
 					     0);
+		if (j->node_bitmap)
+			new->node_bitmap = bit_copy(j->node_bitmap);
 
 		js->cpus_alloc += new->cpus_alloc;
-		js->nodes_alloc += new->nodes_alloc;
 		js->memory_alloc += new->memory_alloc;
+		if (j->node_bitmap) {
+			if (!js->node_bitmap)
+				js->node_bitmap = bit_copy(j->node_bitmap);
+			else
+				bit_or(js->node_bitmap, j->node_bitmap);
+		}
 	}
 
 	/*
@@ -636,10 +644,24 @@ static void _aggregate_job_to_jobs(jobs_stats_t *s, job_stats_t *j)
 	if (IS_JOB_RUNNING(j) || IS_JOB_SUSPENDED(j)) {
 		s->cpus_alloc += j->cpus_alloc;
 		s->memory_alloc += j->memory_alloc;
-		s->nodes_alloc += j->nodes_alloc;
+		if (j->node_bitmap) {
+			if (!s->node_bitmap)
+				s->node_bitmap = bit_copy(j->node_bitmap);
+			else
+				bit_or(s->node_bitmap, j->node_bitmap);
+		}
 	}
 
 	s->job_cnt++;
+}
+
+static int _finalize_ua_nodes_alloc(void *x, void *arg)
+{
+	ua_stats_t *ua = x;
+
+	if (ua->s->node_bitmap)
+		ua->s->nodes_alloc = bit_set_count(ua->s->node_bitmap);
+	return SLURM_SUCCESS;
 }
 
 static int _get_users_accts(void *x, void *args)
@@ -686,6 +708,9 @@ extern jobs_stats_t *statistics_get_jobs(bool lock)
 		lock_slurmctld(job_read_lock);
 
 	list_for_each_ro(job_list, _fill_jobs_statistics, s);
+
+	if (s->node_bitmap)
+		s->nodes_alloc = bit_set_count(s->node_bitmap);
 
 	if (lock)
 		unlock_slurmctld(job_read_lock);
@@ -896,11 +921,15 @@ extern users_accts_stats_t *statistics_get_users_accounts(jobs_stats_t *js)
 
 	list_for_each(js->jobs, _get_users_accts, ua);
 
+	list_for_each(ua->users, _finalize_ua_nodes_alloc, NULL);
+	list_for_each(ua->accounts, _finalize_ua_nodes_alloc, NULL);
+
 	return ua;
 }
 
 extern void statistics_free_jobs(jobs_stats_t *s)
 {
+	FREE_NULL_BITMAP(s->node_bitmap);
 	FREE_NULL_LIST(s->jobs);
 	xfree(s);
 }

--- a/src/slurmctld/statistics.h
+++ b/src/slurmctld/statistics.h
@@ -36,6 +36,7 @@
 #ifndef _STATISTICS_H
 #define _STATISTICS_H
 
+#include "src/common/bitstring.h"
 #include "src/slurmctld/slurmctld.h"
 
 typedef struct node_stats {
@@ -191,6 +192,7 @@ typedef struct job_statistics {
 	uint16_t max_nodes;
 	uint64_t memory_alloc;
 	uint16_t min_nodes;
+	bitstr_t *node_bitmap;
 	uint16_t nodes_alloc;
 	char *partition;
 	uint32_t state_reason;
@@ -213,6 +215,7 @@ typedef struct jobs_statistics {
 	uint32_t job_cnt;
 	list_t *jobs;
 	uint64_t memory_alloc;
+	bitstr_t *node_bitmap;
 	uint16_t nodes_alloc;
 	uint32_t node_failed;
 	uint32_t oom;


### PR DESCRIPTION
## Problem

`slurm_user_jobs_nodes_alloc` and `slurm_jobs_nodes_alloc` report inflated node counts when a user runs multiple sub-node-sized jobs that shared physical nodes.

## Root cause

`nodes_alloc` is computed by summing `total_nodes` across each individual running job for the user. When multiple jobs fit on the same physical node (e.g. jobs requesting only a fraction of a node's CPUs), each job contributed its own `total_nodes = 1` to the sum, even though they all shared the same node.

## Solution

Track node allocation using bitmaps and OR each job's `node_bitmap`. After all jobs have been processed, count the set bits to get the actual number of unique nodes in use.
