### PR TITLE
doc: add Slinky installation and GKE TPU guides to Kubernetes documents

### DIFF
--- a/doc/html/documentation.shtml
+++ b/doc/html/documentation.shtml
@@ -49,6 +49,7 @@ may be found in the <a href="https://slurm.schedmd.com/archive/">archive</a>.
 <li><a href="federation.html">Federated Scheduling Guide</a></li>
 <li><a href="pam_slurm_adopt.html">Job Containment (SSH Session Control) with pam_slurm_adopt</a></li>
 <li><a href="kubernetes.html">Kubernetes Guide</a></li>
+<li><a href="slinky.html">Slinky (Slurm and Kubernetes)</a></li>
 <li><a href="big_sys.html">Large Cluster Administration Guide</a></li>
 <li><a href="licenses.html">License Management</a></li>
 <li><a href="hres.html">Hierarchical Resources (HRES)</a> (in Beta)</li>

--- a/doc/html/kubernetes.shtml
+++ b/doc/html/kubernetes.shtml
@@ -6,39 +6,155 @@
 
 <ul>
   <li><a href="#overview">Overview</a></li>
+  <li><a href="#examples">Examples</a>
+    <ul>
+      <li><a href="#tpu">Running Slurm with TPUs (Slinky on GKE)</a></li>
+    </ul>
+  </li>
   <li><a href="#presentations">Presentations</a></li>
 </ul>
 
-<h2 id="overview">Overview<a class="slurm_link" href="#overview"></a></h2>
+<h3 id="tpu">Running Slurm with TPUs</h3>
 
-<p><a href="https://kubernetes.io/">Kubernetes</a> is being adopted into HPC
-clusters to orchestrate deployments (e.g. software, infrastructure) and run
-certain workloads (e.g. AI/ML inference). There is ongoing interest in
-integrating Kubernetes and Slurm to achieve a unified cluster, optimized
-resource utilization, and workflows that leverage each system.</p>
+<p>To run Slurm workloads with TPU (Tensor Processing Unit) accelerators on Kubernetes via the Slinky Slurm operator,
+  you must first install Slinky on your cluster. For detailed setup steps, see the <a
+    href="slinky.html#installation">Slinky Installation Guide</a>.</p>
 
-<p>The ways in which Slurm and Kubernetes are designed to handle certain types
-of workloads may change over time. Additionally, how they interact with each
-other may change, allowing for new possibilities. This is still an evolving
-area.</p>
+<h4>Worker NodeSet Configuration</h4>
+
+<p>To configure your worker nodes to request TPUs, update the worker NodeSet and Controller in your Helm values file
+  (e.g., <code>values.yaml</code>) to request TPU resources and specify the appropriate node selectors and tolerations:
+</p>
+
+<pre>
+nodesets:
+  tpu:
+    enabled: true
+    scalingMode: StatefulSet
+    replicas: 1
+    slurmd:
+      image:
+        repository: gcr.io/gke-release/slinky/slurmd
+        tag: 25.11-ubuntu24.04-gke.9
+      resources:
+        limits:
+          google.com/tpu: 8
+        requests:
+          google.com/tpu: 8
+    podSpec:
+      nodeSelector:
+        cloud.google.com/gke-tpu-accelerator: tpu-v5-lite-podslice
+        cloud.google.com/gke-tpu-topology: 2x4
+      tolerations:
+        - key: google.com/tpu
+          operator: Exists
+          effect: NoSchedule
+controller:
+  slurmctld:
+    image:
+      repository: gcr.io/gke-release/slinky/slurmctld
+      tag: 25.11-ubuntu24.04-gke.9
+    resources:
+      requests:
+        cpu: 500m
+        memory: 512Mi
+  # Configure the TPU partition in slurm.conf
+  extraConf: |
+    PartitionName=tpu Nodes=tpu State=UP SuspendTime=INFINITE Oversubscribe=Exclusive PowerDownOnIdle=NO ResumeTimeout=300 SuspendTimeout=120
+</pre>
+
+<h4>TPU Environment Variable Propagation</h4>
+
+<p>A key difference when running TPU workloads under Slurm compared to direct Kubernetes execution is environment
+  variable propagation. Kubernetes automatically sets all necessary TPU-related environment variables (e.g.,
+  <code>TPU_ACCELERATOR_TYPE</code>, <code>TPU_TOPOLOGY</code>) in the worker pods. However, Slurm jobs executed via
+  <code>sbatch</code> do not automatically inherit these pod-level environment variables. Without them, JAX or other
+  TPU-enabled frameworks will fail to initialize or time out while attempting to locate the accelerator.
+  </p>
+
+<p>To address this, you must explicitly capture the TPU environment variables from the compute nodes (e.g., via
+  <code>env | grep TPU</code>) and export them inside your Slurm job submission script.
+  </p>
+
+<p>Below is an example of a Slurm batch wrapper script (<code>runner.sh</code>) for a single-host TPU setup (such as a
+  TPU v5e with 8 chips):</p>
+
+<pre>
+#!/bin/bash
+#SBATCH -N 1
+#SBATCH -n 1
+#SBATCH -p tpu
+#SBATCH --job-name=tpu-test
+#SBATCH --output=tpu-test-%j.out
+
+# TPU environment variables (captured from the compute node environment)
+export TPU_ACCELERATOR_TYPE=v5litepod-8
+export TPU_TOPOLOGY=2x4
+export TPU_SKIP_MDS_QUERY=true
+export TPU_CHIPS_PER_HOST_BOUNDS=2,4,1
+export TPU_HOST_BOUNDS=1,1,1
+export TPU_TOPOLOGY_WRAP=false,false,false
+export TPU_TOPOLOGY_ALT=false
+export TPU_RUNTIME_METRICS_PORTS=8431,8432,8433,8434,8435,8436,8437,8438
+
+# JAX single-host configurations
+export JAX_COORDINATOR_ADDRESS="127.0.0.1:8470"
+export TPU_WORKER_ID=0
+export TPU_WORKER_HOSTNAMES="localhost"
+
+ulimit -n 65536
+
+# Execute the user command
+srun python3 $@
+</pre>
+
+<h4>Example JAX Job</h4>
+
+<p>Below is an example JAX Python script (<code>simple_tpu.py</code>) that initializes the distributed runtime and
+  prints the detected TPU devices:</p>
+
+<pre>
+#!/usr/bin/env python3
+import jax
+
+# Initialize the JAX distributed system
+jax.distributed.initialize()
+
+print("--- JAX Distributed Initialized ---")
+print(f"Process Index (Node ID): {jax.process_index()}")
+print(f"Total JAX Processes: {jax.process_count()}")
+print(f"Local Device Count (per host): {jax.local_device_count()}")
+print(f"Total Device Count (global): {jax.device_count()}")
+print(f"Available Devices: {jax.devices()}")
+print("----------------------------------")
+</pre>
+
+<p>Ensure that JAX (with TPU support) is installed in your worker node environment, then submit the job from the login
+  node using:</p>
+
+<pre>
+kubectl exec -n slurm slurm-cluster-login-slinky-xxx -c login -- bash -c "cd /tmp && sbatch runner.sh /tmp/simple_tpu.py"
+</pre>
 
 <h2 id="presentations">Presentations
-<a class="slurm_link" href="#presentations"></a>
+  <a class="slurm_link" href="#presentations"></a>
 </h2>
 
 <p>Note that older presentations may contain outdated information.</p>
 
-<h3>Presentations from 2023</h3>
+<h3 id="2023-presentations">Presentations from 2023
+  <a class="slurm_link" href="#2023-presentations"></a>
+</h3>
 
 <ul>
   <li>
     <a href="https://slurm.schedmd.com/SC23/Slurm-and-or-vs-Kubernetes.pdf">Slurm and/or/vs
-    Kubernetes</a>, Tim Wickberg, SchedMD (SC23, November 2023)
+      Kubernetes</a>, Tim Wickberg, SchedMD (SC23, November 2023)
   </li>
 
   <li>
     <a href="https://slurm.schedmd.com/SLUG23/NERSC-SLUG23.pdf">Never use Slurm HA again: Solve all
-    your problems with Kubernetes</a>, Chris Samuel and Doug Jacobsen, NERSC
+      your problems with Kubernetes</a>, Chris Samuel and Doug Jacobsen, NERSC
     (SLUG23, November 2023)
   </li>
 </ul>

--- a/doc/html/slinky.shtml
+++ b/doc/html/slinky.shtml
@@ -7,22 +7,24 @@
 <ul>
   <li><a href="#overview">Overview</a></li>
   <li><a href="#links">Links</a></li>
+  <li><a href="#installation">Installation</a></li>
   <li><a href="#presentations">Presentations</a></li>
 </ul>
 
 <h2 id="overview">Overview<a class="slurm_link" href="#overview"></a></h2>
 
 <p><a href="https://www.schedmd.com/slinky/why-slinky/">Slinky&trade;</a> is
-SchedMD's set of projects to enable interoperability between Slurm and <a
-href="https://kubernetes.io/">Kubernetes</a>.</p>
+  SchedMD's set of projects to enable interoperability between Slurm and <a
+    href="https://kubernetes.io/">Kubernetes</a>.</p>
 
 <h2 id="links">Links<a class="slurm_link" href="#links"></a></h2>
 
 <p>Slinky documentation can be found <a href="https://slinky.schedmd.com/">here</a>.</p>
 
 <p>Slinky repositories are publicly available on
-<a href="https://github.com/SlinkyProject">GitHub</a> and
-<a href="https://gitlab.com/SchedMD/slinky">GitLab</a>:</p>
+  <a href="https://github.com/SlinkyProject">GitHub</a> and
+  <a href="https://gitlab.com/SchedMD/slinky">GitLab</a>:
+</p>
 
 <ul>
   <li><a href="https://github.com/SlinkyProject/slurm-operator">slurm-operator</a>:
@@ -38,46 +40,121 @@ href="https://kubernetes.io/">Kubernetes</a>.</p>
 </ul>
 
 <p>Public container images and helm chart artifacts can be found
-<a href="https://github.com/orgs/SlinkyProject/packages">here</a>.</p>
+  <a href="https://github.com/orgs/SlinkyProject/packages">here</a>.
+</p>
+
+<h2 id="installation">Installation<a class="slurm_link" href="#installation"></a></h2>
+
+<p>Slinky can be installed on a Kubernetes cluster either by deploying the open-source components manually or by
+  enabling the managed add-on in cloud environments (such as Google Kubernetes Engine).</p>
+
+<h3>Method 1: Open Source Software (OSS) Installation</h3>
+
+<p>For standard Kubernetes clusters, the Slinky operator and its Custom Resource Definitions (CRDs) can be installed
+  using Helm.</p>
+
+<p><b>Step 1: Install cert-manager</b><br>
+  Slinky requires <code>cert-manager</code> to manage certificates for webhook admission controllers. Install it using
+  Helm:</p>
+
+<pre>
+helm repo add jetstack https://charts.jetstack.io
+helm repo update
+helm install cert-manager jetstack/cert-manager \
+  --namespace cert-manager --create-namespace \
+  --set crds.enabled=true
+</pre>
+
+<p><b>Step 2: Install Slinky Operator CRDs</b><br>
+  Deploy the Custom Resource Definitions required by Slinky:</p>
+
+<pre>
+helm install slurm-operator-crds oci://ghcr.io/slinkyproject/charts/slurm-operator-crds \
+  --namespace slinky --create-namespace
+</pre>
+
+<p><b>Step 3: Install the Slinky Operator</b><br>
+  Deploy the operator controller itself:</p>
+
+<pre>
+helm install slurm-operator oci://ghcr.io/slinkyproject/charts/slurm-operator \
+  --namespace slinky
+</pre>
+
+<p><b>Step 4: Deploy a Slurm Cluster</b><br>
+  Once the operator is running, you can define your Slurm cluster specifications in a <code>values.yaml</code> file and
+  deploy the cluster:</p>
+
+<pre>
+helm install slurm-cluster oci://ghcr.io/slinkyproject/charts/slurm \
+  --namespace slurm --create-namespace \
+  -f values.yaml
+</pre>
+
+<h3>Method 2: Managed Operator</h3>
+
+<p>For example, on Google Kubernetes Engine (GKE), Google provides a managed Slurm operator add-on. Enabling the add-on
+  automatically deploys and manages the required Slinky CRDs and operator controller lifecycle on the cluster.</p>
+
+<p><b>Step 1: Enable the SlurmOperator Add-on</b><br>
+  Enable the operator via the <code>gcloud</code> CLI:</p>
+
+<pre>
+gcloud container clusters update CLUSTER_NAME \
+  --zone=ZONE_OR_REGION \
+  --update-addons=SlurmOperator=ENABLED
+</pre>
+
+<p><b>Step 2: Deploy a Slurm Cluster</b><br>
+  Once the managed operator has finished deploying (installing the <code>v1beta1</code> CRDs), you can deploy the Slurm
+  cluster using the OCI Helm chart. Ensure that you target a chart version compatible with the GKE operator's CRD
+  version (e.g., version <code>1.0.2</code>):</p>
+
+<pre>
+helm install slurm-cluster oci://ghcr.io/slinkyproject/charts/slurm \
+  --version 1.0.2 \
+  --namespace slurm --create-namespace \
+  -f values.yaml
+</pre>
 
 <h2 id="presentations">Presentations
-<a class="slurm_link" href="#presentations"></a>
+  <a class="slurm_link" href="#presentations"></a>
 </h2>
 
 <p>Note that older presentations may contain outdated information.</p>
 
 <h3 id="2025-presentations">Presentations from 2025
-<a class="slurm_link" href="#2025-presentations"></a>
+  <a class="slurm_link" href="#2025-presentations"></a>
 </h3>
 
 <ul>
   <li><a href="https://slurm.schedmd.com/MISC25/Slurm_Bridge_KubeCon_25.pdf">
-    Slurm Bridge: Slurm Scheduling Superpowers in Kubernetes</a>,
+      Slurm Bridge: Slurm Scheduling Superpowers in Kubernetes</a>,
     Alan Mutschelknaus and Tim Wickberg, SchedMD (KubeCon NA, November 2025)</li>
   <li><a href="https://slurm.schedmd.com/MISC25/Slurm_Bridge_CNCF-Batch-20250729.pdf">
-    Slurm Bridge</a>, Alan Mutschelknaus, Skyler Malinowski, and Marlow Warnicke,
+      Slurm Bridge</a>, Alan Mutschelknaus, Skyler Malinowski, and Marlow Warnicke,
     SchedMD (CNCF Batch Working Group, July 2025)</li>
   <li><a href="https://slurm.schedmd.com/MISC25/Slinky-CUG2025.pdf">Slinky: The
-    Missing Link Between Slurm and Kubernetes</a>, Skyler Malinowski, Alan
+      Missing Link Between Slurm and Kubernetes</a>, Skyler Malinowski, Alan
     Mutschelknaus, Marlow Warnicke, and Tim Wickberg, SchedMD (CUG25, May 2025)</li>
   <li><a href="https://slurm.schedmd.com/MISC25/Slinky-KubeConEurope2025.pdf">
-    Slinky: Slurm in Kubernetes, Performant AI and HPC Workload Management</a>,
+      Slinky: Slurm in Kubernetes, Performant AI and HPC Workload Management</a>,
     Tim Wickberg, SchedMD (KubeCon Europe, April 2025)</li>
 </ul>
 
 <h3 id="2024-presentations">Presentations from 2024
-<a class="slurm_link" href="#2024-presentations"></a>
+  <a class="slurm_link" href="#2024-presentations"></a>
 </h3>
 
 <ul>
   <li><a href="https://slurm.schedmd.com/SC24/Slinky-CANOPIE.pdf">Slinky: The
-    Missing Link Between Slurm and Kubernetes</a>, Skyler Malinowski and
+      Missing Link Between Slurm and Kubernetes</a>, Skyler Malinowski and
     Tim Wickberg, SchedMD (SC24, November 2024)</li>
   <li><a href="https://slurm.schedmd.com/SLUG24/Slinky-Slurm-Operator.pdf">Slinky
-    &mdash; Slurm Operator</a>, Skyler Malinowski, Alan Mutschelknaus, and
+      &mdash; Slurm Operator</a>, Skyler Malinowski, Alan Mutschelknaus, and
     Marlow Warnicke, SchedMD (SLUG24, September 2024)</li>
   <li><a href="https://slurm.schedmd.com/SLUG24/Slinky-Slurm-Bridge.pdf">Slinky
-    &mdash; Slurm Bridge</a>, Skyler Malinowski, Alan Mutschelknaus, and
+      &mdash; Slurm Bridge</a>, Skyler Malinowski, Alan Mutschelknaus, and
     Marlow Warnicke, SchedMD (SLUG24, September 2024)</li>
 </ul>
 


### PR DESCRIPTION
Updates the kubernetes related docs.
- Added the missing link to the Slinky (Slurm and Kubernetes) guide under the Slurm Administrators section.
- Added the instruction for installing the slurm operator
- Added the instruction for TPU deployment