### PR TITLE
build: replace ld binary format with objcopy

### DIFF
--- a/make_ref.include
+++ b/make_ref.include
@@ -22,7 +22,7 @@ CLEANFILES = *.bino
 BIN_REF = $(REF:.txt=.bino)
 
 %.bino: %.txt
-	$(AM_V_GEN)curr_dir=$(shell pwd); cd $(abs_srcdir); $(LD) -r $(LD_EMULATION) -o "$(abs_builddir)/$*.bino" -z noexecstack --format=binary "$(notdir $<)"; cd $$curr_dir
+	$(AM_V_GEN)curr_dir=$(shell pwd); cd $(abs_srcdir); @OBJCOPY@ -I binary -O default "$(notdir $<)" "$(abs_builddir)/$*.bino"; cd $$curr_dir
 	$(AM_V_at)@OBJCOPY@ --rename-section .data=.rodata,alloc,load,readonly,data,contents "$*.bino"
 
 lib_ref.lo: $(BIN_REF)


### PR DESCRIPTION
## Replace ld --format=binary with objcopy to support modern linkers (mold/lld)
The --format=binary flag is a GNU ld extension not supported by mold or lld. 
```bash
objcopy -I binary -O default
```
 is the POSIX-standard, cross-linker compatible way to embed raw data into ELF objects. This change preserves identical output while enabling builds with alternative linkers.