### PR TITLE
slurmctld: improve error logging for ClusterID initialization

### DIFF
--- a/src/slurmctld/controller.c
+++ b/src/slurmctld/controller.c
@@ -605,7 +605,7 @@ static void _retry_init_db_conn(assoc_init_args_t *args)
 		error("Retrying initial connection to slurmdbd");
 		_init_db_conn();
 		if (!slurm_conf.cluster_id) {
-			error("Still don't know my ClusterID");
+			error("Still don't know my ClusterID: %m");
 			continue;
 		}
 		if (!assoc_mgr_init(acct_db_conn, args, errno))


### PR DESCRIPTION
This PR improves the observability of the slurmctld initialization process.

Problem:
The original error message "Still don't know my ClusterID" lacked context, making it difficult for administrators to diagnose the cause of initialization failures (e.g., distinguishing between network issues or database handshake delays).

Solution:
Added errno to the error message to provide system-level feedback, helping administrators distinguish between various failure states during the initial connection to slurmdbd.