### PR TITLE
Fix multi-QOS per-user/account GRES usage recharged to wrong QOS on reload

### DIFF
--- a/src/slurmctld/job_mgr.c
+++ b/src/slurmctld/job_mgr.c
@@ -1674,6 +1674,26 @@ extern int job_mgr_load_job_state(buf_t *buffer,
 		    !job_ptr->limit_set.qos) {
 			job_fail_qos(job_ptr, __func__, true);
 		} else if (job_ptr->qos_ptr) {
+			/*
+			 * _get_qos_info() resolves a multi-QOS job to the
+			 * highest priority member; keep a running/suspended job
+			 * on its dispatched member (qos_id) instead so reload
+			 * does not misattribute its QOS TRES usage (cf.
+			 * _foreach_cache_update_job()).
+			 */
+			if (job_ptr->qos_list && !IS_JOB_PENDING(job_ptr)) {
+				slurmdb_qos_rec_t *charged_qos_ptr =
+					list_find_first(
+						job_ptr->qos_list,
+						slurmdb_find_qos_in_list,
+						&job_ptr->qos_id);
+				if (charged_qos_ptr)
+					job_ptr->qos_ptr = charged_qos_ptr;
+				else
+					verbose("%s: dispatched QOS %u for %pJ no longer in its QOS list, using highest priority",
+						__func__, job_ptr->qos_id,
+						job_ptr);
+			}
 			job_ptr->qos_id = job_ptr->qos_ptr->id;
 			if (job_ptr->state_reason == FAIL_QOS) {
 				job_ptr->state_reason = WAIT_NO_REASON;

--- a/testsuite/python/tests/test_124_2.py
+++ b/testsuite/python/tests/test_124_2.py
@@ -77,14 +77,6 @@ def setup():
     atf.run_command(f"sacctmgr -i remove qos {QOS_LOW} {QOS_HIGH}", user=su, quiet=True)
 
 
-@pytest.fixture(autouse=True)
-def cancel_jobs_after_test():
-    # Both tests submit the same blocker/victim pair; cancel between tests so the
-    # QOS_HIGH per-user cap is free for the next test's blocker to start.
-    yield
-    atf.cancel_all_jobs(quiet=True)
-
-
 def used_gpu_for_qos(qos_name):
     """Per-user gres/gpu USED for our user under the named QOS, parsed from
     `scontrol -o show assoc_mgr flags=qos` (one QOS per line). Fails loudly if

--- a/testsuite/python/tests/test_124_2.py
+++ b/testsuite/python/tests/test_124_2.py
@@ -3,9 +3,13 @@
 ############################################################################
 # A running multi-QOS job (--qos=low,high) forced to start under the
 # non-highest-priority member must stay attributed to it across a state reload.
-# Before the fix, "scontrol reconfigure" re-resolved the running job to the
+# Before the fix, reloading job state re-resolved the running job to the
 # highest-priority member, flipping its QOS and inflating that member's per-user
 # gres/gpu usage (spuriously tripping QOSMaxGRESPerUser).
+#
+# Two reload paths are exercised, because they are not equivalent: an in-place
+# "scontrol reconfigure" and a slurmctld restart (which reloads job state from
+# StateSaveLocation via job_mgr_load_job_state, the path the fix targets).
 ############################################################################
 import atf
 import re
@@ -73,6 +77,14 @@ def setup():
     atf.run_command(f"sacctmgr -i remove qos {QOS_LOW} {QOS_HIGH}", user=su, quiet=True)
 
 
+@pytest.fixture(autouse=True)
+def cancel_jobs_after_test():
+    # Both tests submit the same blocker/victim pair; cancel between tests so the
+    # QOS_HIGH per-user cap is free for the next test's blocker to start.
+    yield
+    atf.cancel_all_jobs(quiet=True)
+
+
 def used_gpu_for_qos(qos_name):
     """Per-user gres/gpu USED for our user under the named QOS, parsed from
     `scontrol -o show assoc_mgr flags=qos` (one QOS per line). Fails loudly if
@@ -118,6 +130,37 @@ def test_multiqos_gres_usage_survives_reconfigure():
 
     # State reload. Pre-fix this re-attributed the running job_id2 to QOS_HIGH.
     atf.run_command("scontrol reconfigure", user=su, fatal=True)
+
+    # Attribution must be unchanged.
+    assert atf.get_job_parameter(job_id2, "QOS") == QOS_LOW, "QOS flipped on reload"
+    assert used_gpu_for_qos(QOS_LOW) == JOB_GPUS, "QOS_LOW usage lost on reload"
+    assert used_gpu_for_qos(QOS_HIGH) == BLOCK_GPUS, "QOS_HIGH usage inflated on reload"
+
+
+def test_multiqos_gres_usage_survives_restart():
+    # job_id1: blocker fills QOS_HIGH's per-user gpu cap.
+    job_id1 = atf.submit_job_sbatch(
+        f'--account={ACCT} --qos={QOS_HIGH} --gres=gpu:{BLOCK_GPUS} -N1 --wrap "sleep 600"',
+        fatal=True,
+    )
+    atf.wait_for_job_state(job_id1, "RUNNING", fatal=True)
+
+    # job_id2: multi-QOS job cannot fit under QOS_HIGH -> forced onto QOS_LOW.
+    job_id2 = atf.submit_job_sbatch(
+        f'--account={ACCT} --qos={QOS_LOW},{QOS_HIGH} --gres=gpu:{JOB_GPUS} -N1 --wrap "sleep 600"',
+        fatal=True,
+    )
+    atf.wait_for_job_state(job_id2, "RUNNING", fatal=True)
+
+    # Baseline: job_id2 charged to QOS_LOW, job_id1 to QOS_HIGH.
+    assert atf.get_job_parameter(job_id2, "QOS") == QOS_LOW
+    assert used_gpu_for_qos(QOS_LOW) == JOB_GPUS
+    assert used_gpu_for_qos(QOS_HIGH) == BLOCK_GPUS
+
+    # State reload via slurmctld restart (job_mgr_load_job_state path). Pre-fix
+    # this re-attributed the running job_id2 to QOS_HIGH.
+    atf.restart_slurmctld()
+    atf.wait_for_job_state(job_id2, "RUNNING", fatal=True)
 
     # Attribution must be unchanged.
     assert atf.get_job_parameter(job_id2, "QOS") == QOS_LOW, "QOS flipped on reload"

--- a/testsuite/python/tests/test_124_2.py
+++ b/testsuite/python/tests/test_124_2.py
@@ -90,7 +90,9 @@ def used_gpu_for_qos(qos_name):
         if not name or name.group(1) != qos_name:
             continue
         used = re.search(
-            re.escape(user) + r"\(\d+\)=\{[^}]*gres/gpu=\S*?\((\d+)\)", line
+            re.escape(user)
+            + r"\(\d+\)=\{[^}]*?MaxTRESPU=[^}]*?gres/gpu=[^()]*\((\d+)\)",
+            line,
         )
         if not used:
             pytest.fail(f"cannot parse gres/gpu usage for QOS {qos_name}")

--- a/testsuite/python/tests/test_124_2.py
+++ b/testsuite/python/tests/test_124_2.py
@@ -80,10 +80,6 @@ def setup():
 
 
 def used_gpu_for_qos(qos_name):
-    """Per-user gres/gpu USED for our user under the named QOS, parsed from
-    `scontrol -o show assoc_mgr flags=qos` (one QOS per line). Fails loudly if
-    the QOS line is present but the per-user gres/gpu value cannot be parsed, so
-    a format change never silently reads as 0."""
     su = atf.properties["slurm-user"]
     user = atf.get_user_name()
     out = atf.run_command_output(
@@ -100,6 +96,25 @@ def used_gpu_for_qos(qos_name):
         )
         if not used:
             pytest.fail(f"cannot parse gres/gpu usage for QOS {qos_name}")
+        return int(used.group(1))
+    return 0
+
+
+def used_gpu_for_acct_under_qos(qos_name):
+    su = atf.properties["slurm-user"]
+    out = atf.run_command_output(
+        "scontrol -o show assoc_mgr flags=qos", user=su, fatal=True
+    )
+    for line in out.splitlines():
+        name = re.search(r"QOS=([^\s(]+)\(", line)
+        if not name or name.group(1) != qos_name:
+            continue
+        used = re.search(
+            re.escape(ACCT) + r"=\{[^}]*?MaxTRESPA=[^}]*?gres/gpu=[^()]*\((\d+)\)",
+            line,
+        )
+        if not used:
+            pytest.fail(f"cannot parse account gres/gpu usage for QOS {qos_name}")
         return int(used.group(1))
     return 0
 
@@ -125,6 +140,8 @@ def test_multiqos_gres_usage_survives_reconfigure():
     assert atf.get_job_parameter(job_id2, "QOS") == QOS_LOW
     assert used_gpu_for_qos(QOS_LOW) == JOB_GPUS
     assert used_gpu_for_qos(QOS_HIGH) == BLOCK_GPUS
+    assert used_gpu_for_acct_under_qos(QOS_LOW) == JOB_GPUS
+    assert used_gpu_for_acct_under_qos(QOS_HIGH) == BLOCK_GPUS
 
     # State reload. Pre-fix this re-attributed the running job_id2 to QOS_HIGH.
     atf.run_command("scontrol reconfigure", user=su, fatal=True)
@@ -133,6 +150,12 @@ def test_multiqos_gres_usage_survives_reconfigure():
     assert atf.get_job_parameter(job_id2, "QOS") == QOS_LOW, "QOS flipped on reload"
     assert used_gpu_for_qos(QOS_LOW) == JOB_GPUS, "QOS_LOW usage lost on reload"
     assert used_gpu_for_qos(QOS_HIGH) == BLOCK_GPUS, "QOS_HIGH usage inflated on reload"
+    assert (
+        used_gpu_for_acct_under_qos(QOS_LOW) == JOB_GPUS
+    ), "QOS_LOW acct usage lost on reload"
+    assert (
+        used_gpu_for_acct_under_qos(QOS_HIGH) == BLOCK_GPUS
+    ), "QOS_HIGH acct usage inflated on reload"
 
 
 def test_multiqos_gres_usage_survives_restart():
@@ -154,6 +177,8 @@ def test_multiqos_gres_usage_survives_restart():
     assert atf.get_job_parameter(job_id2, "QOS") == QOS_LOW
     assert used_gpu_for_qos(QOS_LOW) == JOB_GPUS
     assert used_gpu_for_qos(QOS_HIGH) == BLOCK_GPUS
+    assert used_gpu_for_acct_under_qos(QOS_LOW) == JOB_GPUS
+    assert used_gpu_for_acct_under_qos(QOS_HIGH) == BLOCK_GPUS
 
     # State reload via slurmctld restart (job_mgr_load_job_state path). Pre-fix
     # this re-attributed the running job_id2 to QOS_HIGH.
@@ -164,3 +189,9 @@ def test_multiqos_gres_usage_survives_restart():
     assert atf.get_job_parameter(job_id2, "QOS") == QOS_LOW, "QOS flipped on reload"
     assert used_gpu_for_qos(QOS_LOW) == JOB_GPUS, "QOS_LOW usage lost on reload"
     assert used_gpu_for_qos(QOS_HIGH) == BLOCK_GPUS, "QOS_HIGH usage inflated on reload"
+    assert (
+        used_gpu_for_acct_under_qos(QOS_LOW) == JOB_GPUS
+    ), "QOS_LOW acct usage lost on reload"
+    assert (
+        used_gpu_for_acct_under_qos(QOS_HIGH) == BLOCK_GPUS
+    ), "QOS_HIGH acct usage inflated on reload"

--- a/testsuite/python/tests/test_124_2.py
+++ b/testsuite/python/tests/test_124_2.py
@@ -72,7 +72,9 @@ def setup():
 
     yield
 
-    atf.run_command(f"sacctmgr -i modify user {user} set qos=normal", user=su, quiet=True)
+    atf.run_command(
+        f"sacctmgr -i modify user {user} set qos=normal", user=su, quiet=True
+    )
     atf.run_command(f"sacctmgr -i remove account {ACCT}", user=su, quiet=True)
     atf.run_command(f"sacctmgr -i remove qos {QOS_LOW} {QOS_HIGH}", user=su, quiet=True)
 
@@ -84,7 +86,9 @@ def used_gpu_for_qos(qos_name):
     a format change never silently reads as 0."""
     su = atf.properties["slurm-user"]
     user = atf.get_user_name()
-    out = atf.run_command_output("scontrol -o show assoc_mgr flags=qos", user=su, fatal=True)
+    out = atf.run_command_output(
+        "scontrol -o show assoc_mgr flags=qos", user=su, fatal=True
+    )
     for line in out.splitlines():
         name = re.search(r"QOS=([^\s(]+)\(", line)
         if not name or name.group(1) != qos_name:

--- a/testsuite/python/tests/test_124_2.py
+++ b/testsuite/python/tests/test_124_2.py
@@ -1,0 +1,125 @@
+############################################################################
+# Copyright (C) SchedMD LLC.
+############################################################################
+# A running multi-QOS job (--qos=low,high) forced to start under the
+# non-highest-priority member must stay attributed to it across a state reload.
+# Before the fix, "scontrol reconfigure" re-resolved the running job to the
+# highest-priority member, flipping its QOS and inflating that member's per-user
+# gres/gpu usage (spuriously tripping QOSMaxGRESPerUser).
+############################################################################
+import atf
+import re
+import pytest
+
+# Test-scoped QOS/account names so a pre-existing local config cannot collide.
+QOS_LOW = "qa_124_2_low"
+QOS_HIGH = "qa_124_2_high"
+ACCT = "qa_124_2_acct"
+
+# One 4-GPU node. QOS_HIGH caps per-user gpu at GPU_CAP; a QOS_HIGH blocker fills
+# that cap so a --qos=QOS_LOW,QOS_HIGH job cannot fit under QOS_HIGH and is
+# forced onto the non-head member QOS_LOW.
+GPU_PER_NODE = 4
+GPU_CAP = 2
+BLOCK_GPUS = 2  # fills QOS_HIGH's per-user cap
+JOB_GPUS = 2  # cannot also fit under QOS_HIGH -> runs under QOS_LOW
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup():
+    atf.require_auto_config("creates QOS, per-user GRES limits and a multi-QOS job")
+    atf.require_config_parameter("SelectType", "select/cons_tres")
+    atf.require_config_parameter("SelectTypeParameters", "CR_CPU")
+    atf.require_config_parameter_includes("GresTypes", "gpu")
+    for i in range(GPU_PER_NODE):
+        atf.require_tty(i)
+    atf.require_config_parameter(
+        "Name", {"gpu": {"File": f"/dev/tty[0-{GPU_PER_NODE - 1}]"}}, source="gres"
+    )
+    atf.require_nodes(1, [("Gres", f"gpu:{GPU_PER_NODE}"), ("CPUs", GPU_PER_NODE)])
+    atf.require_accounting(modify=True)
+    atf.require_config_parameter_includes("AccountingStorageTRES", "gres/gpu")
+    atf.require_config_parameter_includes("AccountingStorageEnforce", "qos")
+    atf.require_config_parameter_includes("AccountingStorageEnforce", "limits")
+    atf.require_slurm_running()
+
+    su = atf.properties["slurm-user"]
+    user = atf.get_user_name()
+    atf.run_command(f"sacctmgr -i add qos {QOS_LOW} Priority=1", user=su, fatal=True)
+    atf.run_command(
+        f"sacctmgr -i add qos {QOS_HIGH} Priority=100 MaxTRESPerUser=gres/gpu={GPU_CAP}",
+        user=su,
+        fatal=True,
+    )
+    atf.run_command(f"sacctmgr -i add account {ACCT}", user=su, fatal=True)
+    atf.run_command(
+        f"sacctmgr -i add user {user} DefaultAccount={ACCT} account={ACCT} "
+        f"qos=normal,{QOS_LOW},{QOS_HIGH}",
+        user=su,
+        fatal=True,
+    )
+    # Wait until the controller has ingested the account association (and thus
+    # the QOS) so the first submit below cannot race association propagation.
+    atf.repeat_until(
+        lambda: atf.run_command_output("scontrol show assoc_mgr flags=assoc", user=su),
+        lambda out: re.search(rf"Account={ACCT}\b", out) is not None,
+        fatal=True,
+    )
+
+    yield
+
+    atf.run_command(f"sacctmgr -i modify user {user} set qos=normal", user=su, quiet=True)
+    atf.run_command(f"sacctmgr -i remove account {ACCT}", user=su, quiet=True)
+    atf.run_command(f"sacctmgr -i remove qos {QOS_LOW} {QOS_HIGH}", user=su, quiet=True)
+
+
+def used_gpu_for_qos(qos_name):
+    """Per-user gres/gpu USED for our user under the named QOS, parsed from
+    `scontrol -o show assoc_mgr flags=qos` (one QOS per line). Fails loudly if
+    the QOS line is present but the per-user gres/gpu value cannot be parsed, so
+    a format change never silently reads as 0."""
+    su = atf.properties["slurm-user"]
+    user = atf.get_user_name()
+    out = atf.run_command_output("scontrol -o show assoc_mgr flags=qos", user=su, fatal=True)
+    for line in out.splitlines():
+        name = re.search(r"QOS=([^\s(]+)\(", line)
+        if not name or name.group(1) != qos_name:
+            continue
+        used = re.search(
+            re.escape(user) + r"\(\d+\)=\{[^}]*gres/gpu=\S*?\((\d+)\)", line
+        )
+        if not used:
+            pytest.fail(f"cannot parse gres/gpu usage for QOS {qos_name}")
+        return int(used.group(1))
+    return 0
+
+
+def test_multiqos_gres_usage_survives_reconfigure():
+    su = atf.properties["slurm-user"]
+
+    # job_id1: blocker fills QOS_HIGH's per-user gpu cap.
+    job_id1 = atf.submit_job_sbatch(
+        f'--account={ACCT} --qos={QOS_HIGH} --gres=gpu:{BLOCK_GPUS} -N1 --wrap "sleep 600"',
+        fatal=True,
+    )
+    atf.wait_for_job_state(job_id1, "RUNNING", fatal=True)
+
+    # job_id2: multi-QOS job cannot fit under QOS_HIGH -> forced onto QOS_LOW.
+    job_id2 = atf.submit_job_sbatch(
+        f'--account={ACCT} --qos={QOS_LOW},{QOS_HIGH} --gres=gpu:{JOB_GPUS} -N1 --wrap "sleep 600"',
+        fatal=True,
+    )
+    atf.wait_for_job_state(job_id2, "RUNNING", fatal=True)
+
+    # Baseline: job_id2 charged to QOS_LOW, job_id1 to QOS_HIGH.
+    assert atf.get_job_parameter(job_id2, "QOS") == QOS_LOW
+    assert used_gpu_for_qos(QOS_LOW) == JOB_GPUS
+    assert used_gpu_for_qos(QOS_HIGH) == BLOCK_GPUS
+
+    # State reload. Pre-fix this re-attributed the running job_id2 to QOS_HIGH.
+    atf.run_command("scontrol reconfigure", user=su, fatal=True)
+
+    # Attribution must be unchanged.
+    assert atf.get_job_parameter(job_id2, "QOS") == QOS_LOW, "QOS flipped on reload"
+    assert used_gpu_for_qos(QOS_LOW) == JOB_GPUS, "QOS_LOW usage lost on reload"
+    assert used_gpu_for_qos(QOS_HIGH) == BLOCK_GPUS, "QOS_HIGH usage inflated on reload"


### PR DESCRIPTION
## Problem

A job can be submitted with more than one QOS (`--qos=a,b`). It runs under whichever member the scheduler picked, and its GRES/TRES usage is accounted to that member (saved in `job_ptr->qos_id`).

When the controller recovers job state from `StateSaveLocation` (a `slurmctld` restart or a backup takeover) it re-reads each running job and resets its QOS to the **head of the QOS list** instead of the member it actually started under, then recharges its per-user/per-account usage there. The list head is the first `--qos` member after sorting by priority; when the listed QOS share the same priority, the head is simply the **first one listed**.

So every running multi-QOS job a user has is re-attributed to that single head QOS, regardless of which member it really ran under. The head QOS's usage counter then grows past what is physically running, and new jobs are blocked with `QOSMaxGRESPerUser`. In production the head QOS's per-user counter showed ~976 GPUs in use while the user was actually running only ~300 (the two QOS had equal priority, so the head was just the first one in the job's `--qos` list).

Where it goes wrong: `job_mgr_load_job_state()` resolves the QOS via `_get_qos_info()`, which returns `list_peek()` (the list head) and overwrites `job_ptr->qos_id` with it; `_restore_job_accounting()` then recharges usage against that member.

The in-place `scontrol reconfigure` path is affected in Slurm 25.05 version but it got fixed in the future version, 25.11.

## Fix

At state recovery, keep a running/suspended multi-QOS job on the member it was dispatched under (`job_ptr->qos_id`); only pending jobs fall back to the list head. This mirrors the pending-vs-running handling already in `_foreach_cache_update_job()`, and makes accounting reflect the QOS the job is physically running under.

That is the whole fix: one change in `job_mgr_load_job_state()`. The `qos_ptr` restore already present in `_adjust_limit_usage()` keeps `acct_policy_add_job_submit()` from leaving the job on the head member before the subsequent `JOB_BEGIN`, so nothing else is needed.

(Note for backports: on 25.05 that restore in `_adjust_limit_usage()` runs only for `ACCT_POLICY_REM_SUBMIT`, so the `ADD_SUBMIT` highest-QOS bump is left in place and this `job_mgr.c` change alone is not sufficient there; a 25.05 backport also needs `_adjust_limit_usage()` to skip `_set_highest_prio_qos_ptr()` for running jobs.)

## Target Release

Targets `26.05.2` Slurm release. This is a minor patch to an existing bug.

## Issue

Reported in SchedMD support ticket: https://support.schedmd.com/show_bug.cgi?id=23033

## Testing

Regression testing: added an ATF test (`testsuite/python/tests/test_124_2.py`) with two cases:
- `test_multiqos_gres_usage_survives_reconfigure` guards the in-place cache-rebuild path.
- `test_multiqos_gres_usage_survives_restart` exercises the state-recovery path this fix targets; it fails on unpatched 26.05 and passes with the fix.

Functional testing: verified end-to-end on a from-source 26.05 cluster, comparing a plain-`26.05` build against the patched build and triggering a `slurmctld` restart:

```bash
sbatch --qos=high     --gres=gpu:2 --wrap "sleep 900"   # fills high's per-user cap (MaxTRESPerUser=gres/gpu=2)
sbatch --qos=low,high --gres=gpu:2 --wrap "sleep 900"   # forced onto non-head 'low'
scontrol -o show assoc_mgr flags=qos     # per-user gres/gpu used
# restart slurmctld (recovers job state from StateSaveLocation)
scontrol -o show assoc_mgr flags=qos     # re-check
```

| per-user gres/gpu | before fix | after fix |
|---|---|---|
| pre-restart  | `low=2 high=2` | `low=2 high=2` |
| post-restart | `low=0 high=4` (job re-attributed to the head) | `low=2 high=2` (stays on `low`) |

(For reference, `scontrol reconfigure` was also tested and is unaffected on 26.05, before and after the fix.)
