### PR TITLE
Expose per-node job memory to slurmd Prolog

### DIFF
--- a/doc/html/prolog_epilog.shtml
+++ b/doc/html/prolog_epilog.shtml
@@ -483,6 +483,10 @@ Available in SrunProlog, TaskProlog, SrunEpilog and TaskEpilog.</li>
 <li><b>SLURM_JOB_ACCOUNT</b>
 Account name used for the job.</li>
 
+<li><b>SLURM_JOB_ALLOC_MEM_PER_NODE</b>
+Effective memory allocated to the job on the current slurmd node, in MiB.
+Available in Prolog.</li>
+
 <li><b>SLURM_JOB_COMMENT</b>
 Comment added to the job.
 Available in Prolog, PrologSlurmctld, Epilog and EpilogSlurmctld.</li>

--- a/doc/html/prolog_epilog.shtml
+++ b/doc/html/prolog_epilog.shtml
@@ -483,6 +483,13 @@ Available in SrunProlog, TaskProlog, SrunEpilog and TaskEpilog.</li>
 <li><b>SLURM_JOB_ACCOUNT</b>
 Account name used for the job.</li>
 
+<li><b>SLURM_JOB_ALLOC_MEM_PER_NODE</b>
+Memory allocated to the job on current node, in MiB.
+A --mem-per-cpu request is multiplied out, and --mem=0 is expanded to the
+node's real memory less MemSpecLimit.
+Only set when memory is a consumable resource (see SelectTypeParameters).
+Available in Prolog.</li>
+
 <li><b>SLURM_JOB_COMMENT</b>
 Comment added to the job.
 Available in Prolog, PrologSlurmctld, Epilog and EpilogSlurmctld.</li>

--- a/src/interfaces/cred.c
+++ b/src/interfaces/cred.c
@@ -435,14 +435,33 @@ extern char *slurm_cred_get_signature_key(slurm_cred_t *cred)
 	return key;
 }
 
-extern void slurm_cred_get_mem(slurm_cred_t *credential, char *node_name,
-			       const char *func_name,
-			       uint64_t *job_mem_limit,
-			       uint64_t *step_mem_limit)
+static int _get_rep_count_inx(uint32_t *rep_count, uint32_t rep_count_size,
+			      int inx, bool quiet)
 {
-	slurm_cred_arg_t *cred = credential->arg;
-	int rep_idx = -1;
-	int node_id = -1;
+	if (!quiet)
+		return slurm_get_rep_count_inx(rep_count, rep_count_size, inx);
+
+	for (int i = 0; i < rep_count_size; i++) {
+		if (!rep_count[i])
+			return -1;
+	}
+
+	return slurm_get_rep_count_inx(rep_count, rep_count_size, inx);
+}
+
+static bool _get_job_mem(slurm_cred_arg_t *cred, char *node_name,
+			 const char *func_name, uint64_t *job_mem_limit,
+			 bool quiet)
+{
+	int node_id = -1, rep_idx = -1;
+
+	if (!cred->job_hostlist || !cred->job_mem_alloc ||
+	    !cred->job_mem_alloc_rep_count || !cred->job_mem_alloc_size) {
+		if (!quiet)
+			error("%s: job memory allocation data is incomplete",
+			      func_name);
+		return false;
+	}
 
 	/*
 	 * Batch steps only have the job_hostlist set and will always be 0 here.
@@ -451,20 +470,42 @@ extern void slurm_cred_get_mem(slurm_cred_t *credential, char *node_name,
 		rep_idx = 0;
 	} else if ((node_id =
 		    nodelist_find(cred->job_hostlist, node_name)) >= 0) {
-		rep_idx = slurm_get_rep_count_inx(cred->job_mem_alloc_rep_count,
-					          cred->job_mem_alloc_size,
-						  node_id);
+		rep_idx = _get_rep_count_inx(cred->job_mem_alloc_rep_count,
+					     cred->job_mem_alloc_size, node_id,
+					     quiet);
 
-	} else {
+	} else if (!quiet) {
 		error("Unable to find %s in job hostlist: `%s'",
 		      node_name, cred->job_hostlist);
 	}
 
-	if (rep_idx < 0)
-		error("%s: node_id=%d, not found in job_mem_alloc_rep_count requested job memory not reset.",
-		      func_name, node_id);
-	else
-		*job_mem_limit = cred->job_mem_alloc[rep_idx];
+	if (rep_idx < 0) {
+		if (!quiet)
+			error("%s: node_id=%d, not found in job_mem_alloc_rep_count requested job memory not reset.",
+			      func_name, node_id);
+		return false;
+	}
+
+	*job_mem_limit = cred->job_mem_alloc[rep_idx];
+	return true;
+}
+
+extern bool slurm_cred_get_job_mem(slurm_cred_t *credential, char *node_name,
+				   uint64_t *job_mem_limit)
+{
+	return _get_job_mem(credential->arg, node_name, NULL, job_mem_limit,
+			    true);
+}
+
+extern void slurm_cred_get_mem(slurm_cred_t *credential, char *node_name,
+			       const char *func_name, uint64_t *job_mem_limit,
+			       uint64_t *step_mem_limit)
+{
+	slurm_cred_arg_t *cred = credential->arg;
+	int rep_idx = -1;
+	int node_id = -1;
+
+	(void) _get_job_mem(cred, node_name, func_name, job_mem_limit, false);
 
 	if (!step_mem_limit) {
 		log_flag(CPU_BIND, "%s: Memory extracted from credential for %ps job_mem_limit= %"PRIu64,

--- a/src/interfaces/cred.h
+++ b/src/interfaces/cred.h
@@ -245,6 +245,13 @@ extern void *slurm_cred_get(slurm_cred_t *cred,
 			    cred_data_enum_t cred_data_type);
 
 /*
+ * Get the job memory allocation for a node without logging errors.
+ * RET - true on success, false if the allocation cannot be determined
+ */
+extern bool slurm_cred_get_job_mem(slurm_cred_t *cred, char *node_name,
+				   uint64_t *job_mem_limit);
+
+/*
  * Return index in rep_count array corresponding to absolute node index
  * cred - job credential to use for memory setting
  * node_name - name of host

--- a/src/plugins/prep/script/prep_script_slurmd.c
+++ b/src/plugins/prep/script/prep_script_slurmd.c
@@ -36,6 +36,7 @@
 #include "config.h"
 
 #include <glob.h>
+#include <inttypes.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
@@ -65,6 +66,8 @@ slurmd_conf_t *conf = NULL;
 
 static char **_build_env(job_env_t *job_env, slurm_cred_t *cred,
 			 bool is_epilog);
+static bool _get_job_alloc_mem_per_node(slurm_cred_arg_t *cred_arg,
+					uint64_t *alloc_mem);
 static int _run_spank_job_script(const char *mode, char **env, uint32_t job_id,
 				 bool is_epilog);
 
@@ -220,6 +223,43 @@ extern int slurmd_script(job_env_t *job_env, slurm_cred_t *cred,
 	return rc;
 }
 
+static bool _get_job_alloc_mem_per_node(slurm_cred_arg_t *cred_arg,
+					uint64_t *alloc_mem)
+{
+	int node_id, rep_idx = -1;
+
+	if (!cred_arg->job_hostlist || !cred_arg->job_mem_alloc ||
+	    !cred_arg->job_mem_alloc_rep_count || !cred_arg->job_mem_alloc_size)
+		goto skip;
+
+	if ((node_id = nodelist_find(cred_arg->job_hostlist, conf->node_name)) <
+	    0)
+		goto skip;
+
+	for (uint32_t i = 0; i < cred_arg->job_mem_alloc_size; i++)
+		if (!cred_arg->job_mem_alloc_rep_count[i])
+			goto skip;
+
+	/* Batch credentials only carry the batch node's memory allocation. */
+	if (cred_arg->step_id.step_id == SLURM_BATCH_SCRIPT)
+		rep_idx = 0;
+	else
+		rep_idx = slurm_get_rep_count_inx(
+			cred_arg->job_mem_alloc_rep_count,
+			cred_arg->job_mem_alloc_size, node_id);
+	if ((rep_idx < 0) ||
+	    ((uint32_t) rep_idx >= cred_arg->job_mem_alloc_size))
+		goto skip;
+
+	*alloc_mem = cred_arg->job_mem_alloc[rep_idx];
+	return true;
+
+skip:
+	debug2("%s: unable to get SLURM_JOB_ALLOC_MEM_PER_NODE on node %s",
+	       __func__, conf->node_name);
+	return false;
+}
+
 /* NOTE: call env_array_free() to free returned value */
 static char **_build_env(job_env_t *job_env, slurm_cred_t *cred,
 			 bool is_epilog)
@@ -292,10 +332,15 @@ static char **_build_env(job_env_t *job_env, slurm_cred_t *cred,
 
 	if (cred) {
 		slurm_cred_arg_t *cred_arg = slurm_cred_get_args(cred);
+		uint64_t alloc_mem;
 
 		if (cred_arg->job_account)
 			setenvf(&env, "SLURM_JOB_ACCOUNT", "%s",
 				cred_arg->job_account);
+		if (!is_epilog &&
+		    _get_job_alloc_mem_per_node(cred_arg, &alloc_mem))
+			setenvf(&env, "SLURM_JOB_ALLOC_MEM_PER_NODE",
+				"%" PRIu64, alloc_mem);
 		if (cred_arg->job_comment)
 			setenvf(&env, "SLURM_JOB_COMMENT", "%s",
 				cred_arg->job_comment);

--- a/src/plugins/prep/script/prep_script_slurmd.c
+++ b/src/plugins/prep/script/prep_script_slurmd.c
@@ -36,6 +36,7 @@
 #include "config.h"
 
 #include <glob.h>
+#include <inttypes.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
@@ -296,6 +297,20 @@ static char **_build_env(job_env_t *job_env, slurm_cred_t *cred,
 		if (cred_arg->job_account)
 			setenvf(&env, "SLURM_JOB_ACCOUNT", "%s",
 				cred_arg->job_account);
+		if (!is_epilog) {
+			uint64_t alloc_mem;
+
+			if (slurm_cred_get_job_mem(cred, conf->node_name,
+						   &alloc_mem)) {
+				if (alloc_mem)
+					setenvf(&env,
+						"SLURM_JOB_ALLOC_MEM_PER_NODE",
+						"%" PRIu64, alloc_mem);
+			} else {
+				debug2("%s: unable to get SLURM_JOB_ALLOC_MEM_PER_NODE on node %s",
+				       __func__, conf->node_name);
+			}
+		}
 		if (cred_arg->job_comment)
 			setenvf(&env, "SLURM_JOB_COMMENT", "%s",
 				cred_arg->job_comment);

--- a/testsuite/expect/test31.3
+++ b/testsuite/expect/test31.3
@@ -79,7 +79,7 @@ reconfigure -fail
 
 # Test whether env vars exist in Prolog and Epilog
 log_info "Checking for regular env vars"
-set job_id [submit_job -fail "-t1 -N1 -w$test_node -o/dev/null --comment=foo --extra=bar --wrap='hostname'"]
+set job_id [submit_job -fail "-t1 -N1 -w$test_node --mem=1 -o/dev/null --comment=foo --extra=bar --wrap='hostname'"]
 
 wait_for_job $job_id "DONE"
 
@@ -103,6 +103,8 @@ check_epilog "SLURM_JOB_UID="
 
 check_prolog "SLURM_JOB_USER="
 check_epilog "SLURM_JOB_USER="
+
+check_prolog "SLURM_JOB_ALLOC_MEM_PER_NODE=1"
 
 check_prolog "SLURM_SCRIPT_CONTEXT=prolog_slurmd"
 check_epilog "SLURM_SCRIPT_CONTEXT=epilog_slurmd"


### PR DESCRIPTION
## Summary

Expose `SLURM_JOB_ALLOC_MEM_PER_NODE` to slurmd Prolog scripts. The value is the effective job memory allocation for the current slurmd node, in MiB.

## Implementation

- Reuse the credential memory resolver for batch handling, node lookup, and compressed allocation arrays.
- Add a quiet, status-returning job-memory getter so Prolog can safely skip the variable and log at debug level when the value cannot be determined.
- Document the variable.

This does not add an RPC or change scheduling or memory enforcement behavior. The variable is intentionally available only in slurmd Prolog, not Epilog.

## Testing

- `make -j4`
- `git clang-format --diff origin/master -- src/interfaces/cred.c src/interfaces/cred.h src/plugins/prep/script/prep_script_slurmd.c`
- `pre-commit run --show-diff-on-failure --files doc/html/prolog_epilog.shtml src/interfaces/cred.c src/interfaces/cred.h src/plugins/prep/script/prep_script_slurmd.c`
- `pre-commit run gitlint --hook-stage commit-msg --commit-msg-filename .git/COMMIT_EDITMSG`
- `git diff --check origin/master...HEAD`
