### PR TITLE
auth/jwt: Fix missing 'alg' check in _verify_rs256_jwt()

### DIFF
--- a/src/plugins/auth/jwt/auth_jwt.c
+++ b/src/plugins/auth/jwt/auth_jwt.c
@@ -317,9 +317,9 @@ static data_for_each_cmd_t _verify_rs256_jwt(data_t *d, void *arg)
 	int rc;
 	foreach_rs256_args_t *args = (foreach_rs256_args_t *) arg;
 
-	/* Ignore non-RS256 keys in the JWKS */
-	alg = data_get_string(data_key_get(d, "alg"));
-	if (xstrcasecmp(alg, "RS256"))
+	/* Ignore non-RS256 keys in the JWKS if algorithm is provided */
+	if ((alg = data_get_string(data_key_get(d, "alg"))) &&
+	    xstrcasecmp(alg, "RS256"))
 		return DATA_FOR_EACH_CONT;
 
 	/* Return early if this key doesn't match */


### PR DESCRIPTION
The previous fix (commit 19f42376) correctly handled the optional 'alg' field in _build_jwks_keys(), but missed the same issue in _verify_rs256_jwt(). When a JWKS key has no 'alg' field, data_get_string() returns NULL and xstrcasecmp(NULL, "RS256") is non-zero, causing every key to be skipped at verification time with "could not find matching kid or decode failed".

Apply the same fix pattern to _verify_rs256_jwt() so keys without an 'alg' field are not incorrectly skipped during token verification.

Bug 16168