### PR TITLE
Fix UID/GID overflow, display, and JWT identity override issues

### DIFF
--- a/src/common/uid.c
+++ b/src/common/uid.c
@@ -692,7 +692,7 @@ int gid_from_string(const char *name, gid_t *gidp)
 	errno = 0;
 	l = strtol(name, &p, 10);
 	if (((errno == ERANGE) && ((l == LONG_MIN) || (l == LONG_MAX))) ||
-	    (name == p) || (*p != '\0') || (l < 0) || (l > INT_MAX)) {
+	    (name == p) || (*p != '\0') || (l < 0) || (l > UINT32_MAX)) {
 		xfree(buf_malloc);
 		return -1;
 	}

--- a/src/plugins/auth/jwt/auth_jwt.c
+++ b/src/plugins/auth/jwt/auth_jwt.c
@@ -372,7 +372,7 @@ static void _handle_identity(jwt_t *jwt, auth_token_t *cred)
 
 	if (cred->id) {
 		if (cred->username &&
-		    !xstrcmp(cred->username, cred->id->pw_name)) {
+		    xstrcmp(cred->username, cred->id->pw_name)) {
 			error("%s: cannot override identity for %s with requested user %s",
 			      __func__, cred->id->pw_name, cred->username);
 			FREE_NULL_IDENTITY(cred->id);

--- a/src/plugins/data_parser/v0.0.43/parsers.c
+++ b/src/plugins/data_parser/v0.0.43/parsers.c
@@ -2158,8 +2158,16 @@ static int PARSE_FUNC(USER_ID)(const parser_t *const parser, void *obj,
 					   src);
 		/* fall through */
 	case DATA_TYPE_INT_64:
-		uid = data_get_int(src);
+	{
+		int64_t tmp_val = data_get_int(src);
+		if ((tmp_val < 0) || (tmp_val > UINT32_MAX))
+			return parse_error(parser, args, parent_path,
+					   ESLURM_USER_ID_INVALID,
+					   "Invalid user ID (overflow): %" PRId64,
+					   tmp_val);
+		uid = tmp_val;
 		break;
+	}
 	case DATA_TYPE_STRING:
 	{
 		int rc;
@@ -2197,11 +2205,6 @@ static int PARSE_FUNC(USER_ID)(const parser_t *const parser, void *obj,
 		fatal_abort("invalid type");
 	}
 
-	if (uid >= INT_MAX)
-		return parse_error(parser, args, parent_path,
-				   ESLURM_USER_ID_INVALID,
-				   "Invalid user ID: %d", uid);
-
 	*uid_ptr = uid;
 
 	return SLURM_SUCCESS;
@@ -2222,8 +2225,16 @@ static int PARSE_FUNC(GROUP_ID)(const parser_t *const parser, void *obj,
 					   src);
 		/* fall through */
 	case DATA_TYPE_INT_64:
-		gid = data_get_int(src);
+	{
+		int64_t tmp_val = data_get_int(src);
+		if ((tmp_val < 0) || (tmp_val > UINT32_MAX))
+			return parse_error(parser, args, parent_path,
+					   ESLURM_GROUP_ID_INVALID,
+					   "Invalid group ID (overflow): %" PRId64,
+					   tmp_val);
+		gid = tmp_val;
 		break;
+	}
 	case DATA_TYPE_STRING:
 	{
 		int rc;
@@ -2260,11 +2271,6 @@ static int PARSE_FUNC(GROUP_ID)(const parser_t *const parser, void *obj,
 	case DATA_TYPE_MAX:
 		fatal_abort("invalid type");
 	}
-
-	if (gid >= INT_MAX)
-		return parse_error(parser, args, parent_path,
-				   ESLURM_GROUP_ID_INVALID,
-				   "Invalid group ID: %d", gid);
 
 	*gid_ptr = gid;
 

--- a/src/plugins/data_parser/v0.0.44/parsers.c
+++ b/src/plugins/data_parser/v0.0.44/parsers.c
@@ -2169,8 +2169,16 @@ static int PARSE_FUNC(USER_ID)(const parser_t *const parser, void *obj,
 					   src);
 		/* fall through */
 	case DATA_TYPE_INT_64:
-		uid = data_get_int(src);
+	{
+		int64_t tmp_val = data_get_int(src);
+		if ((tmp_val < 0) || (tmp_val > UINT32_MAX))
+			return parse_error(parser, args, parent_path,
+					   ESLURM_USER_ID_INVALID,
+					   "Invalid user ID (overflow): %" PRId64,
+					   tmp_val);
+		uid = tmp_val;
 		break;
+	}
 	case DATA_TYPE_STRING:
 	{
 		int rc;
@@ -2208,11 +2216,6 @@ static int PARSE_FUNC(USER_ID)(const parser_t *const parser, void *obj,
 		fatal_abort("invalid type");
 	}
 
-	if (uid >= INT_MAX)
-		return parse_error(parser, args, parent_path,
-				   ESLURM_USER_ID_INVALID,
-				   "Invalid user ID: %d", uid);
-
 	*uid_ptr = uid;
 
 	return SLURM_SUCCESS;
@@ -2233,8 +2236,16 @@ static int PARSE_FUNC(GROUP_ID)(const parser_t *const parser, void *obj,
 					   src);
 		/* fall through */
 	case DATA_TYPE_INT_64:
-		gid = data_get_int(src);
+	{
+		int64_t tmp_val = data_get_int(src);
+		if ((tmp_val < 0) || (tmp_val > UINT32_MAX))
+			return parse_error(parser, args, parent_path,
+					   ESLURM_GROUP_ID_INVALID,
+					   "Invalid group ID (overflow): %" PRId64,
+					   tmp_val);
+		gid = tmp_val;
 		break;
+	}
 	case DATA_TYPE_STRING:
 	{
 		int rc;
@@ -2271,11 +2282,6 @@ static int PARSE_FUNC(GROUP_ID)(const parser_t *const parser, void *obj,
 	case DATA_TYPE_MAX:
 		fatal_abort("invalid type");
 	}
-
-	if (gid >= INT_MAX)
-		return parse_error(parser, args, parent_path,
-				   ESLURM_GROUP_ID_INVALID,
-				   "Invalid group ID: %d", gid);
 
 	*gid_ptr = gid;
 

--- a/src/plugins/data_parser/v0.0.45/parsers.c
+++ b/src/plugins/data_parser/v0.0.45/parsers.c
@@ -2182,8 +2182,16 @@ static int PARSE_FUNC(USER_ID)(const parser_t *const parser, void *obj,
 					   src);
 		/* fall through */
 	case DATA_TYPE_INT_64:
-		uid = data_get_int(src);
+	{
+		int64_t tmp_val = data_get_int(src);
+		if ((tmp_val < 0) || (tmp_val > UINT32_MAX))
+			return parse_error(parser, args, parent_path,
+					   ESLURM_USER_ID_INVALID,
+					   "Invalid user ID (overflow): %" PRId64,
+					   tmp_val);
+		uid = tmp_val;
 		break;
+	}
 	case DATA_TYPE_STRING:
 	{
 		int rc;
@@ -2220,11 +2228,6 @@ static int PARSE_FUNC(USER_ID)(const parser_t *const parser, void *obj,
 	case DATA_TYPE_MAX:
 		fatal_abort("invalid type");
 	}
-
-	if (uid >= INT_MAX)
-		return parse_error(parser, args, parent_path,
-				   ESLURM_USER_ID_INVALID,
-				   "Invalid user ID: %d", uid);
 
 	*uid_ptr = uid;
 
@@ -2273,8 +2276,16 @@ static int PARSE_FUNC(GROUP_ID)(const parser_t *const parser, void *obj,
 					   src);
 		/* fall through */
 	case DATA_TYPE_INT_64:
-		gid = data_get_int(src);
+	{
+		int64_t tmp_val = data_get_int(src);
+		if ((tmp_val < 0) || (tmp_val > UINT32_MAX))
+			return parse_error(parser, args, parent_path,
+					   ESLURM_GROUP_ID_INVALID,
+					   "Invalid group ID (overflow): %" PRId64,
+					   tmp_val);
+		gid = tmp_val;
 		break;
+	}
 	case DATA_TYPE_STRING:
 	{
 		int rc;
@@ -2311,11 +2322,6 @@ static int PARSE_FUNC(GROUP_ID)(const parser_t *const parser, void *obj,
 	case DATA_TYPE_MAX:
 		fatal_abort("invalid type");
 	}
-
-	if (gid >= INT_MAX)
-		return parse_error(parser, args, parent_path,
-				   ESLURM_GROUP_ID_INVALID,
-				   "Invalid group ID: %d", gid);
 
 	*gid_ptr = gid;
 

--- a/src/plugins/data_parser/v0.0.46/parsers.c
+++ b/src/plugins/data_parser/v0.0.46/parsers.c
@@ -2182,8 +2182,16 @@ static int PARSE_FUNC(USER_ID)(const parser_t *const parser, void *obj,
 					   src);
 		/* fall through */
 	case DATA_TYPE_INT_64:
-		uid = data_get_int(src);
+	{
+		int64_t tmp_val = data_get_int(src);
+		if ((tmp_val < 0) || (tmp_val > UINT32_MAX))
+			return parse_error(parser, args, parent_path,
+					   ESLURM_USER_ID_INVALID,
+					   "Invalid user ID (overflow): %" PRId64,
+					   tmp_val);
+		uid = tmp_val;
 		break;
+	}
 	case DATA_TYPE_STRING:
 	{
 		int rc;
@@ -2220,11 +2228,6 @@ static int PARSE_FUNC(USER_ID)(const parser_t *const parser, void *obj,
 	case DATA_TYPE_MAX:
 		fatal_abort("invalid type");
 	}
-
-	if (uid >= INT_MAX)
-		return parse_error(parser, args, parent_path,
-				   ESLURM_USER_ID_INVALID,
-				   "Invalid user ID: %d", uid);
 
 	*uid_ptr = uid;
 
@@ -2273,8 +2276,16 @@ static int PARSE_FUNC(GROUP_ID)(const parser_t *const parser, void *obj,
 					   src);
 		/* fall through */
 	case DATA_TYPE_INT_64:
-		gid = data_get_int(src);
+	{
+		int64_t tmp_val = data_get_int(src);
+		if ((tmp_val < 0) || (tmp_val > UINT32_MAX))
+			return parse_error(parser, args, parent_path,
+					   ESLURM_GROUP_ID_INVALID,
+					   "Invalid group ID (overflow): %" PRId64,
+					   tmp_val);
+		gid = tmp_val;
 		break;
+	}
 	case DATA_TYPE_STRING:
 	{
 		int rc;
@@ -2311,11 +2322,6 @@ static int PARSE_FUNC(GROUP_ID)(const parser_t *const parser, void *obj,
 	case DATA_TYPE_MAX:
 		fatal_abort("invalid type");
 	}
-
-	if (gid >= INT_MAX)
-		return parse_error(parser, args, parent_path,
-				   ESLURM_GROUP_ID_INVALID,
-				   "Invalid group ID: %d", gid);
 
 	*gid_ptr = gid;
 

--- a/src/squeue/print.c
+++ b/src/squeue/print.c
@@ -421,6 +421,13 @@ int _print_int(int number, int width, bool right, bool cut_output)
 	return _print_str(buf, width, right, cut_output);
 }
 
+static int _print_uint(unsigned int number, int width, bool right, bool cut_output)
+{
+	char buf[32];
+
+	snprintf(buf, 32, "%u", number);
+	return _print_str(buf, width, right, cut_output);
+}
 
 int _print_secs(long time, int width, bool right, bool cut_output)
 {
@@ -846,7 +853,7 @@ int _print_job_user_id(job_info_t * job, int width, bool right, char* suffix)
 	if (job == NULL)	/* Print the Header instead */
 		_print_str("UID", width, right, true);
 	else
-		_print_int(job->user_id, width, right, true);
+		_print_uint(job->user_id, width, right, true);
 	if (suffix)
 		printf("%s", suffix);
 	return SLURM_SUCCESS;
@@ -870,7 +877,7 @@ int _print_job_group_id(job_info_t * job, int width, bool right, char* suffix)
 	if (job == NULL)	/* Print the Header instead */
 		_print_str("GROUP", width, right, true);
 	else
-		_print_int(job->group_id, width, right, true);
+		_print_uint(job->group_id, width, right, true);
 	if (suffix)
 		printf("%s", suffix);
 	return SLURM_SUCCESS;
@@ -2706,7 +2713,7 @@ int _print_step_user_id(job_step_info_t * step, int width, bool right,
 	if (step == NULL)	/* Print the Header instead */
 		_print_str("UID", width, right, true);
 	else
-		_print_int(step->user_id, width, right, true);
+		_print_uint(step->user_id, width, right, true);
 	if (suffix)
 		printf("%s", suffix);
 	return SLURM_SUCCESS;


### PR DESCRIPTION
GCP OS Login generates UID/GIDs up to 2^32. This PR allows users having UIDs falling between 2^31 and 2^32 to submit jobs via Slurm REST API. This also fixes issue, that user could not impersonate themselves in the POSIX identity passed in JWT token.

- Fix gid_from_string to allow GIDs up to UINT32_MAX.
- Remove INT_MAX checks in data_parser plugins to allow UIDs/GIDs in range (2^31..2^32-1) in slurmrestd.
- Add overflow checks around data_get_int in data_parser plugins to prevent 32-bit wrap-around.
- Fix JWT identity override check in auth_jwt.c to correctly reject mismatched identities instead of matching ones.
- Fix squeue display to format UIDs/GIDs as unsigned (%u).
