### PR TITLE
slurmdbd - StoragePassScript is never executed on 26.05

### DIFF
--- a/src/slurmdbd/slurmdbd.c
+++ b/src/slurmdbd/slurmdbd.c
@@ -230,6 +230,7 @@ int main(int argc, char **argv)
 	assoc_init_args_t assoc_init_arg;
 
 	_init_config();
+	closeall_init();
 	log_init(argv[0], log_opts, LOG_DAEMON, NULL);
 	if (read_slurmdbd_conf())
 		exit(1);


### PR DESCRIPTION
With `StoragePassScript` configured, slurmdbd cannot obtain a database password. It forks a child for the script, the child burns a full CPU core for minutes without ever running it, and slurmdbd logs:

```
error: run_command_poll_child: token_script poll timeout @ 10000 msec
error: mysql_common: token_script execution timed out
```

This works on 25.11. It is broken in every 26.05 release and still broken on `master`.

## Cause

slurmdbd never calls `closeall_init()`, which 26.05.0rc1 made a prerequisite for `closeall()`. slurmctld, slurmd, slurmstepd, sackd and every client (through `slurm_init()`) call it; slurmdbd builds its own startup sequence in `main()` and calls neither. `close_range_f` then stays `NULL` and `rlimit_nofile` stays `INT_MAX`, so `closeall_except()` falls back to closing descriptors one at a time up to `INT_MAX`. `StoragePassScript` is the only `run_command()` caller reachable from slurmdbd (`mysql_common.c:_execute_pw_script()`), so its child spends roughly 2.1 billion `close()` calls in `_run_command_child_pre_exec()` before it can `execve()` the script. The `xassert(closeall_initialized)` meant to catch this is compiled out unless `--enable-developer` is used, so nothing is logged.

gdb on the live child, while the parent was still in `poll()`:

```
#0  close () from /lib64/libc.so.6
#1  closeall_except (fd=<optimized out>, skipped=0x0) at fd.c:157
#2  closeall (fd=3) at fd.c:228
#3  _run_command_child_pre_exec () at run_command.c:324
#4  _run_command_child (launcher_argv=0x0, ...) at run_command.c:245
#5  run_command (args=...) at run_command.c:410
```

## Fix

Call `closeall_init()` after `_init_config()`, which is where `rlimits_use_max_nofile()` raises `RLIMIT_NOFILE`, so the cached limit is correct on kernels without `close_range()`. `src/common/fd.h` is already included by `slurmdbd.c`.

## Two related issues, not addressed here

1. **`max_wait` cannot be enforced before the child becomes a process group leader.** On timeout, `run_command_poll_child()` calls `_kill_pg(cpid)`, but the child only reaches `setpgid(0, 0)` after `closeall(3)`, so until then `killpg()` matches no process group and fails with `ESRCH` — and the discarded return value hides that. The code then blocks in `waitpid(cpid, status, 0)`. That is why this bug presents as a multi-minute hang despite a
10 s timeout, and why the runaway child is never killed. Calling `setpgid(0, 0)` at the top of `_run_command_child()` instead fixes it for both the direct and launcher paths. Happy to send that as a separate patch.

2. **slurmdbd is the only fork-capable daemon not using the script launcher.** It calls neither `run_command_init()` nor `run_command_is_launcher()`, so its children run `closeall()`, `setpgid()`, `setresuid()` and `error()` post-`fork()` in a multithreaded address space. `closeall_except()` takes `log_lock` via `log_closeall_pre()`, and `pthread_mutex_lock()` is not async-signal-safe, so any thread holding `log_lock` at `fork()` time deadlocks the child and produces the same unkillable-child symptom nondeterministically.