### PR TITLE
jobcomp/elasticsearch: Basic auth for backend connection

### DIFF
--- a/doc/html/elasticsearch.shtml
+++ b/doc/html/elasticsearch.shtml
@@ -76,6 +76,19 @@ do so when trying to index the first job document.
 </li>
 </ul>
 
+<p>There are two environment variables related to this plugin:</p>
+
+<ul>
+<li>
+<b>SLURM_JOBCOMP_USERNAME</b>
+can be set to the username for basic auth on the Elasticsearch server.
+</li>
+<li>
+<b>SLURM_JOBCOMP_PASSWORD</b>
+can be set to the password for basic auth on the Elasticsearch server.
+</li>
+</ul>
+
 <h2 id="visualization">Visualization
 <a class="slurm_link" href="#visualization"></a>
 </h2>

--- a/src/plugins/jobcomp/elasticsearch/jobcomp_elasticsearch.c
+++ b/src/plugins/jobcomp/elasticsearch/jobcomp_elasticsearch.c
@@ -106,6 +106,8 @@ struct job_node {
 
 char *save_state_file = "elasticsearch_state";
 char *log_url = NULL;
+char *username = NULL;
+char *password = NULL;
 
 static pthread_cond_t location_cond = PTHREAD_COND_INITIALIZER;
 static pthread_mutex_t location_mutex = PTHREAD_MUTEX_INITIALIZER;
@@ -178,9 +180,10 @@ static int _index_job(const char *jobcomp)
 		return SLURM_ERROR;
 	}
 
-	rc = slurm_curl_request(jobcomp, log_url, NULL, NULL, NULL, NULL, NULL,
-				slist, 0, &response_str, &response_code,
-				HTTP_REQUEST_POST, false, false);
+	rc = slurm_curl_request(jobcomp, log_url, username, password, NULL,
+			NULL, NULL, slist, 0, &response_str,
+			&response_code, HTTP_REQUEST_POST, false,
+			false);
 	/*
 	 * HTTP 200 (OK)	- request succeed.
 	 * HTTP 201 (Created)	- request succeed and resource created.
@@ -315,6 +318,8 @@ extern int init(void)
 	slurm_mutex_lock(&pend_jobs_lock);
 	(void) _load_pending_jobs();
 	slurm_mutex_unlock(&pend_jobs_lock);
+	username = getenv("SLURM_JOBCOMP_USERNAME");
+	password = getenv("SLURM_JOBCOMP_PASSWORD");
 
 	if (slurm_curl_init())
 		return SLURM_ERROR;


### PR DESCRIPTION
Changelog: jobcomp/elasticsearch - backend authentication (basic auth) using username/password from environment.

<!--
Thank you for contributing to Slurm!

All contributions must target the master branch. Backports to stable releases
are handled by maintainers as appropriate.

If your patch addresses a security vulnerability, please follow the instructions
in SECURITY.md rather than opening a pull request.

All commits must carry a Signed-off-by trailer (git commit -s). By doing so
you certify agreement with the Developer Certificate of Origin in CONTRIBUTING.md.
See CONTRIBUTING.md for full submission guidelines.
-->

## What problem does this fix?

To the best of our knowledge there is no possibility at the moment to configure an authenticated connection to the Elastic backend.

## How do you reproduce the problem?

Try to configure connection to an Elastic backend with mandatory authentication.

## How does the patch solve it?

This pull request provides a minimal implementation for basic authentication using username and password from environment variables:

- `SLURM_JOBCOMP_USERNAME`
- `SLURM_JOBCOMP_PASSWORD`

If those are not defined `getenv()` still returns a NULL pointer, so no change to the previous behavior.
The patch is designed to have reasonable minimal code changes.
We've built and tested it based on [Slurm 25.11](https://github.com/SchedMD/slurm/tree/slurm-25.11) as the HPC site requiring the functionality runs that version at the moment of writing.

<!-- Walk the reviewer through the key changes. -->

## Checklist

- [x] All commits are signed off (`Signed-off-by:` present)
- [x] At least one commit has a `Changelog:` trailer
- [x] Patches are logically separated and each compiles independently
- [-] Non-functional changes (formatting, spelling) are in a separate commit - not included in this PR
- [x] Docs are updated (`--help`, man page, HTML) if behavior changed
- [-] `Makefile.am` is submitted, not `Makefile.in` - not included in this PR
