### PR TITLE
Add alignment attribute to objcopy symbols

### DIFF
--- a/src/common/ref.h
+++ b/src/common/ref.h
@@ -47,9 +47,9 @@
  *
  * ld will replace any '.' with '_'.
  */
-#define decl_static_data(name)                     \
-	extern const void *_binary_##name##_start; \
-	extern const void *_binary_##name##_end;   \
+#define decl_static_data(name) \
+	extern const void *_binary_##name##_start __attribute__((aligned(1))); \
+	extern const void *_binary_##name##_end __attribute__((aligned(1))); \
 	extern const void *_binary_##name##_size;
 
 /*


### PR DESCRIPTION
Changelog: Add alignment attribute to objcopy symbols to indicate potentially non-ABI compliant alignment of these symbols to the compiler

<!--
Thank you for contributing to Slurm!

All contributions must target the master branch. Backports to stable releases
are handled by maintainers as appropriate.

If your patch addresses a security vulnerability, please follow the instructions
in SECURITY.md rather than opening a pull request.

All commits must carry a Signed-off-by trailer (git commit -s). By doing so
you certify agreement with the Developer Certificate of Origin in CONTRIBUTING.md.
See CONTRIBUTING.md for full submission guidelines.
-->

## What problem does this fix?

This fixes a build problem on s390x, and potentially other platforms, where global symbols are expected to have a certain alignment.

Building on s390x the linker complains about an `R_390_PC32DBL` relocation applied to a symbol at an odd address. The problem arises because these special symbols are introduced by objcopy to wrap binary data embedded into the binary. The resulting address depends on the size of the binary blobs being inserted.

```
/bin/sh ../../libtool  --tag=CC   --mode=link gcc  -DNUMA_VERSION1_COMPATIBILITY -g -O2 -fno-omit-frame-pointer -pthread -ggdb3 -Wall -g -O1 -fno-strict-aliasing   -o sackd sackd.o -Wl,-rpath=/home/andreas/slurm/install/lib/slurm -L../../src/api/.libs -lslurmfull -export-dynamic lib_ref.la -lpthread -lm -lresolv 
libtool: link: gcc -DNUMA_VERSION1_COMPATIBILITY -g -O2 -fno-omit-frame-pointer -ggdb3 -Wall -g -O1 -fno-strict-aliasing -o .libs/sackd sackd.o -Wl,-rpath=/home/andreas/slurm/install/lib/slurm -Wl,--export-dynamic  -L../../src/api/.libs /home/andreas/slurm/slurm/src/api/.libs/libslurmfull.so ./.libs/lib_ref.a -lpthread -lm -lresolv -pthread -Wl,-rpath -Wl,/home/andreas/slurm/install/lib/slurm
/usr/bin/ld.bfd: sackd.o(.text+0x5fa): relocation R_390_PC32DBL against misaligned symbol `_binary_usage_txt_end' (0x1004ce9) in ./.libs/lib_ref.a(usage.bino)
/usr/bin/ld.bfd: final link failed
collect2: error: ld returned 1 exit status
```

## How do you reproduce the problem?

Build upstream slurm on s390x.

## How does the patch solve it?

The commit adds aligned(1) attributes to the extern symbol declarations to make the compiler aware of these symbols being potentially misaligned. GCC on s390x will then avoid using instructions which require even addresses.

## Checklist

- [x] All commits are signed off (`Signed-off-by:` present)
- [x] At least one commit has a `Changelog:` trailer
- [x] Patches are logically separated and each compiles independently
- [ ] Non-functional changes (formatting, spelling) are in a separate commit
- [ ] Docs are updated (`--help`, man page, HTML) if behavior changed
- [ ] `Makefile.am` is submitted, not `Makefile.in`
