### PR TITLE
Add alloc_sid to the lua job_submit plugin 

### DIFF
--- a/src/plugins/job_submit/lua/job_submit_lua.c
+++ b/src/plugins/job_submit/lua/job_submit_lua.c
@@ -511,6 +511,8 @@ static int _get_job_req_field(const job_desc_msg_t *job_desc, const char *name)
 		lua_pushstring(L, job_desc->admin_comment);
 	} else if (!xstrcmp(name, "alloc_node")) {
 		lua_pushstring(L, job_desc->alloc_node);
+	} else if (!xstrcmp(name, "alloc_sid")) {
+		lua_pushnumber(L, job_desc->alloc_sid);
 	} else if (!xstrcmp(name, "argc")) {
 		lua_pushnumber(L, job_desc->argc);
 	} else if (!xstrcmp(name, "argv")) {
@@ -827,6 +829,8 @@ static int _set_job_req_field(lua_State *L)
 		xfree(job_desc->admin_comment);
 		if (strlen(value_str))
 			job_desc->admin_comment = xstrdup(value_str);
+	} else if (!xstrcmp(name, "alloc_sid")) {
+		job_desc->alloc_sid = luaL_checknumber(L, 3);
 	} else if (!xstrcmp(name, "array_inx")) {
 		value_str = luaL_checkstring(L, 3);
 		xfree(job_desc->array_inx);

--- a/src/slurmctld/job_mgr.c
+++ b/src/slurmctld/job_mgr.c
@@ -7704,7 +7704,8 @@ static int _job_create(job_desc_msg_t *job_desc, bool allocate, int will_run,
 	 */
 	job_ptr->priority = job_desc->priority;
 	if (job_ptr->priority == 0) {
-		if (user_submit_priority == 0)
+		if ((user_submit_priority == 0) &&
+		    (job_desc->alloc_sid != ALLOC_SID_ADMIN_HOLD))
 			job_ptr->state_reason = WAIT_HELD_USER;
 		else
 			job_ptr->state_reason = WAIT_HELD;


### PR DESCRIPTION
Changelog: Add alloc_sid to the lua job_submit plugin which permits setting an Admin Hold on jobs.

<!--
Thank you for contributing to Slurm!

All contributions must target the master branch. Backports to stable releases
are handled by maintainers as appropriate.

If your patch addresses a security vulnerability, please follow the instructions
in SECURITY.md rather than opening a pull request.

All commits must carry a Signed-off-by trailer (git commit -s). By doing so
you certify agreement with the Developer Certificate of Origin in CONTRIBUTING.md.
See CONTRIBUTING.md for full submission guidelines.
-->

## What problem does this fix?

It isn't possible to set an Admin Hold on jobs in the Lua job_submit plugin.

## How do you reproduce the problem?

Attempt to set an admin hold in a Lua job submit script:

```lua
    job_desc.priority = 0
    job_desc.alloc_sid = slurm.ALLOC_SID_ADMIN_HOLD
```

## How does the patch solve it?

Adds the ability to read and set this field from Lua and stops reason from being set to `JobHeldUser` if `ALLOC_SID_ADMIN_HOLD` is set.

<!-- Walk the reviewer through the key changes. -->

## Checklist

- [x] All commits are signed off (`Signed-off-by:` present)
- [x] At least one commit has a `Changelog:` trailer
- [x] Patches are logically separated and each compiles independently
- [x] Non-functional changes (formatting, spelling) are in a separate commit
- [ ] Docs are updated (`--help`, man page, HTML) if behavior changed
- [x] `Makefile.am` is submitted, not `Makefile.in`
